### PR TITLE
fixed invalid cargo ids and random seed

### DIFF
--- a/main.nut
+++ b/main.nut
@@ -42,6 +42,10 @@ class MainClass extends GSController
 
 function MainClass::Start()
 {
+	// Wait random number of ticks (less than one day) based on system time to ensure random number seed
+	local sysdate = GSDate.GetSystemTime() % 70;
+    this.Sleep(sysdate);
+
 	// Initializing the script
 	local start_tick = GSController.GetTick();
 

--- a/town.nut
+++ b/town.nut
@@ -64,7 +64,7 @@ class GoalTown
 			this.limit_mails = ::TownDataTable[this.id].limit_mails;
 			this.limit_growth = (this.limit_passangers[1] > 0) || (this.limit_mails[1] > 0);
 			this.limit_delay = ::TownDataTable[this.id].limit_delay;
-			this.cargo_hash = ::TownDataTable[this.id].cargo_hash_upper << 32 | ::TownDataTable[this.id].cargo_hash_lower;
+			this.cargo_hash = (::TownDataTable[this.id].cargo_hash_upper + 0x7FFFFFFF << 32) | (::TownDataTable[this.id].cargo_hash_lower + 0X7FFFFFFF);
 			this.town_cargo_cat = GetCargoTable(this.cargo_hash);
 			this.DebugCargoTable(this.town_cargo_cat);
 			
@@ -115,8 +115,8 @@ function GoalTown::SavingTownData()
 	town_data.limit_passangers <- this.limit_passangers;
 	town_data.limit_mails <- this.limit_mails;
 	town_data.limit_delay <- this.limit_delay;
-	town_data.cargo_hash_upper <- this.cargo_hash >> 32;
-	town_data.cargo_hash_lower <- this.cargo_hash & ((1 << 32) - 1);
+	town_data.cargo_hash_upper <- ((this.cargo_hash >> 32) - 0X7FFFFFFF);
+	town_data.cargo_hash_lower <- ((this.cargo_hash & 0xFFFFFFFF) - 0X7FFFFFFF);
 	return town_data;
 }
 


### PR DESCRIPTION
Closes #7 

Fixed integer overflow when saving cargo hash. Cargo hash has 64 bits and squirrel uses 64 bit integers. But saving data only uses 32 bit integers. The value is casted into 64 bit integer and if the value overflew into negative numbers, the bits 32-63 are all ones, changing the result value. So to maintain the same value after loading, it is necessary to split the number into upper and lower part and convert it to integer range before saving. When loading, the value is converted back into unsigned int range.

Added randomization of random seed at the start of the script.