### PR TITLE
Default cargo categories

### DIFF
--- a/cargo.nut
+++ b/cargo.nut
@@ -640,7 +640,7 @@ function DefineCargosBySettings(economy)
 				       [1,4,8,9,10,14,15,19,21,30,32,37,41,45,51,52,53,55,61],
 				       [3,5,7,11,17,18,20,22,36,39,42,56,57,58]];
 			::CargoCatList <- [CatLabels.PUBLIC_SERVICES,CatLabels.RAW_FOOD,CatLabels.RAW_MATERIALS,
-					   CatLabels.PROCESSED_MATERIALS,CatLabels.IMPORTED_GOODS]; // FIXME: Imported goods to final products
+					   CatLabels.PROCESSED_MATERIALS,CatLabels.FINAL_PRODUCTS];
 			::CargoMinPopDemand <- [0,500,1000,4000,8000];
 			::CargoPermille <- [60,25,25,15,10];
 			::CargoDecay <- [0.4,0.2,0.2,0.1,0.1];
@@ -706,8 +706,7 @@ function InitCargoLists()
 	DebugCargoLabels();       	// Debug info: print cargo labels
 
 	local economy = DiscoverEconomyType(); 	// Get economy type based on cargo list
-	// DefineCargosBySettings(economy); 		// Define cargo data accordingly to industry set
-	DefineCargosBySettings(Economies.NONE); // FIXME: Remove me
+	DefineCargosBySettings(economy); 		// Define cargo data accordingly to industry set
 
 	// Initializing some useful and often used variables
 	::CargoCatNum <- ::CargoCat.len();

--- a/cargo.nut
+++ b/cargo.nut
@@ -646,6 +646,7 @@ function DefineCargosBySettings(economy)
 			::CargoDecay <- [0.4,0.2,0.2,0.1,0.1];
 			break;
 		default:
+			CreateDefaultCargoCat();
 			break;
 	}
 
@@ -673,24 +674,12 @@ function DefineCargosBySettings(economy)
  * industry sets and cargoscheme supported by the script. 
  */
 function DiscoverEconomyType() {
-	local cargo_list = [];
-	for(local i = 0; i < 64; ++i) {
-		cargo_list.append(GSCargo.GetCargoLabel(i));
-	}
-
 	local economy = Economies.NONE;
 	for (local i = 1; i < 26; ++i) {
-		local economy_cargo_list = GetEconomyCargoList(i, cargo_list);
-		if (CompareCargoLists(economy_cargo_list, cargo_list)) {
-			::CargoIDList <- cargo_list;
-			economy = i;
+		local economy_cargo_list = GetEconomyCargoList(i, ::CargoIDList);
+		if (CompareCargoLists(economy_cargo_list, ::CargoIDList)) {
+			return economy;
 		}
-	}
-
-	// This is used to add all null IDs after the end of active used cargos
-	local missing_cargo = 64 - ::CargoIDList.len();
-	for (local i = 0; i < missing_cargo; i++) {
-		for (local i = 0; i < missing_cargo; i++) ::CargoIDList.append(null);
 	}
 
 	return economy;
@@ -709,16 +698,16 @@ function CompareCargoLists(list1, list2) {
 /* Initialization of cargo data. */
 function InitCargoLists()
 {
-	DebugCargoLabels();       	// Debug info: print cargo labels
-
-	local economy = DiscoverEconomyType(); // Get economy type based on cargo list
-	if (economy == Economies.NONE) {
-		::CargoIDList <- false;
-		Log.Info("Warning: game's cargo list differ from settings.", Log.LVL_INFO);
-		return false;
+	::CargoIDList <- [];
+	for(local i = 0; i < 64; ++i) {
+		::CargoIDList.append(GSCargo.GetCargoLabel(i));
 	}
 
-	DefineCargosBySettings(economy); 	// Define cargo data accordingly to industry set
+	DebugCargoLabels();       	// Debug info: print cargo labels
+
+	local economy = DiscoverEconomyType(); 	// Get economy type based on cargo list
+	// DefineCargosBySettings(economy); 		// Define cargo data accordingly to industry set
+	DefineCargosBySettings(Economies.NONE); // FIXME: Remove me
 
 	// Initializing some useful and often used variables
 	::CargoCatNum <- ::CargoCat.len();
@@ -793,7 +782,7 @@ function GetCargoHash(cargo_cat)
 }
 
 /* Create cargo table from cargo hash */
-function GetCargoTable(hash) // TODO: Randomization 2
+function GetCargoTable(hash)
 {
 	local cargo_cat = array(::CargoCatNum);
 
@@ -810,4 +799,142 @@ function GetCargoTable(hash) // TODO: Randomization 2
 	}
 
 	return cargo_cat;
+}
+
+function IsRawCargo(cargo)
+{
+	local industry_list = GSIndustryList_CargoProducing(cargo);
+	industry_list.Valuate(GSIndustry.GetIndustryType);
+	industry_list.Sort(GSList.SORT_BY_VALUE, true);
+	
+	while (industry_list.Count() > 0) {
+		local industry_type = industry_list.GetValue(industry_list.Begin());
+		if (GSIndustryType.IsRawIndustry(industry_type))
+			return 1;
+		industry_list.RemoveValue(industry_type);
+	}
+
+	return 0;
+}
+
+function CreateDefaultCargoCat()
+{
+	::CargoLimiter <- [0,2];
+	::CargoCat <- [[0,2]];
+	::CargoCatList <- [CatLabels.CATEGORY_I];
+	::CargoMinPopDemand <- [0];
+	::CargoPermille <- [60];
+	::CargoDecay <- [0.4];
+
+	local cargo_list = GSCargoList();
+	cargo_list.RemoveItem(0); // PASS
+	cargo_list.RemoveItem(2); // MAIL
+	cargo_list.Valuate(IsRawCargo);
+
+	// RAW CARGOS
+	local raw_list = GSList();
+	raw_list.AddList(cargo_list);
+	raw_list.KeepValue(1);
+
+	if (raw_list.Count() > 10) {
+		::CargoCat.append([]);
+		::CargoCat.append([]);
+
+		::CargoCatList.append(CatLabels.CATEGORY_II);
+		::CargoCatList.append(CatLabels.CATEGORY_III);
+		::CargoMinPopDemand.append(500);
+		::CargoMinPopDemand.append(1000);
+		::CargoPermille.append(25);
+		::CargoPermille.append(25);
+		::CargoDecay.append(0.2);
+		::CargoDecay.append(0.2);
+
+		raw_list.Valuate(GSBase.RandItem);
+		raw_list.Sort(GSList.SORT_BY_VALUE, GSList.SORT_ASCENDING);
+
+		local cargo = raw_list.Begin();
+		local index = 0;
+		while (!raw_list.IsEnd()) {
+			if (index < (raw_list.Count() + 1) / 2)
+				::CargoCat[1].append(cargo);
+			else
+				::CargoCat[2].append(cargo);
+			cargo = raw_list.Next();
+			++index;
+		}
+	}
+	else {
+		::CargoCat.append([]);
+		::CargoCatList.append(CatLabels.CATEGORY_II);
+		::CargoMinPopDemand.append(1000);
+		::CargoPermille.append(45);
+		::CargoDecay.append(0.2);
+
+		foreach (cargo, _ in raw_list) {
+			::CargoCat[1].append(cargo);
+		}
+	}
+
+	// PROCESSED CARGOS
+	local processed_list = GSList();
+	processed_list.AddList(cargo_list);
+	processed_list.KeepValue(0);
+
+	if (processed_list.Count() > 10) {
+		::CargoCat.append([]);
+		::CargoCat.append([]);
+		if (::CargoCatList.top() == CatLabels.CATEGORY_III) {
+			::CargoCatList.append(CatLabels.CATEGORY_IV);
+			::CargoCatList.append(CatLabels.CATEGORY_V);
+		}
+		else {
+			::CargoCatList.append(CatLabels.CATEGORY_III);
+			::CargoCatList.append(CatLabels.CATEGORY_IV);
+		}
+		::CargoMinPopDemand.append(4000);
+		::CargoMinPopDemand.append(8000);
+		::CargoPermille.append(15);
+		::CargoPermille.append(15);
+		::CargoDecay.append(0.1);
+		::CargoDecay.append(0.1);
+
+		processed_list.Valuate(GSBase.RandItem);
+		processed_list.Sort(GSList.SORT_BY_VALUE, GSList.SORT_ASCENDING);
+
+		local cargo = processed_list.Begin();
+		local index = 0;
+		local shift = ::CargoCatList.top() == CatLabels.CATEGORY_V ? 3 : 2;
+		while (!processed_list.IsEnd()) {
+			if (index < (processed_list.Count() + 1) / 2)
+				::CargoCat[shift].append(cargo);
+			else
+				::CargoCat[shift + 1].append(cargo);
+			cargo = processed_list.Next();
+			++index;
+		}
+	}
+	else {
+		::CargoCat.append([]);
+		if (::CargoCatList.top() == CatLabels.CATEGORY_III)
+			::CargoCatList.append(CatLabels.CATEGORY_IV);
+		else
+			::CargoCatList.append(CatLabels.CATEGORY_III);
+		::CargoMinPopDemand.append(4000);
+		::CargoPermille.append(15);
+		::CargoDecay.append(0.1);
+
+		local index = ::CargoCatList.top() == CatLabels.CATEGORY_IV ? 3 : 2;
+		foreach (cargo, _ in processed_list) {
+			::CargoCat[index].append(cargo);
+		}
+	}
+
+	local cargo_text = "";
+	foreach (index, cat in ::CargoCat) {
+		cargo_text += "  " + (index + 1) + ": ";
+		foreach (cargo in cat) {
+			cargo_text += GSCargo.GetCargoLabel(cargo) + ",";
+		}
+	}
+	Log.Info(cargo_text, Log.LVL_SUB_DECISIONS);
 }

--- a/cargo.nut
+++ b/cargo.nut
@@ -678,7 +678,7 @@ function DiscoverEconomyType() {
 	for (local i = 1; i < 26; ++i) {
 		local economy_cargo_list = GetEconomyCargoList(i, ::CargoIDList);
 		if (CompareCargoLists(economy_cargo_list, ::CargoIDList)) {
-			return economy;
+			return i;
 		}
 	}
 
@@ -800,6 +800,7 @@ function GetCargoTable(hash)
 	return cargo_cat;
 }
 
+/* Checks if one of the industry types that produce this cargo is a raw industry */
 function IsRawCargo(cargo)
 {
 	local industry_list = GSIndustryList_CargoProducing(cargo);

--- a/lang/english.txt
+++ b/lang/english.txt
@@ -34,8 +34,6 @@ STR_SB_CARGOCAT_1        :{STRING} {NUM}: {GREEN}{STRING}{BLACK}{}{STRING}: {SIL
 STR_SB_CARGOCAT_2        :{STRING} {NUM}: {RED}{STRING}{BLACK}{}{STRING}: {SILVER}{NUM}{BLACK} {STRING}: {SILVER}{NUM}%{BLACK}{}{STRING}: {CARGO_LIST}
 STR_SB_CARGOCAT_3        :{STRING} {NUM}: {BROWN}{STRING}{BLACK}{}{STRING}: {SILVER}{NUM}{BLACK} {STRING}: {SILVER}{NUM}%{BLACK}{}{STRING}: {CARGO_LIST}
 STR_SB_CARGOCAT_4        :{STRING} {NUM}: {PURPLE}{STRING}{BLACK}{}{STRING}: {SILVER}{NUM}{BLACK} {STRING}: {SILVER}{NUM}%{BLACK}{}{STRING}: {CARGO_LIST}
-STR_SB_WARNING_TITLE     :Warning
-STR_SB_WARNING_1         :The cargo categories could not be created for this industry set. The game script is turned off.
 
 ##### TOWNBOX #####
 STR_TOWNBOX_CATEGORY            :Cargo information: supplied / required{STRING}

--- a/main.nut
+++ b/main.nut
@@ -225,8 +225,7 @@ function MainClass::Load(version, saved_data)
 {
 	Log.Info("Loading data...", Log.LVL_INFO);
 	// Loading town data. Only load data if the savegame version matches.
-	if ((saved_data.rawin("save_version") && saved_data.save_version == this.current_save_version)
-		|| (version == 4 && saved_data.save_version == 6)) { // FIXME: remove with new major version
+	if ((saved_data.rawin("save_version") && saved_data.save_version == this.current_save_version)) {
 		this.load_saved_data = true;
 		foreach (townid, town_data in saved_data.town_data_table) {
 			::TownDataTable[townid] <- town_data;

--- a/story.nut
+++ b/story.nut
@@ -82,15 +82,6 @@ function StoryEditor::CargoInfoPage()
 	}
 }
 
-/* Issue an initial warning if game's cargo list doesn't match with settings. */
-function StoryEditor::CargoWarningPage()
-{
-	// Creating the page
-	local sp_warning = this.NewStoryPage(GSCompany.COMPANY_INVALID, GSText(GSText.STR_SB_WARNING_TITLE));
-	GSStoryPage.NewElement(sp_warning, GSStoryPage.SPET_TEXT, 0, GSText(GSText.STR_SB_WARNING_1));
-	GSStoryPage.Show(sp_warning);
-}
-
 /* Create the StoryBook if it still doesn't exist. This function is
  * called only when (re)initializing all data, because the existing
  * storybook is stored by OTTD.

--- a/strings.nut
+++ b/strings.nut
@@ -179,9 +179,8 @@ function GoalTown::TownSignText()
 /* Helper function: get a list of currently used cargo labels/ID. */
 function DebugCargoLabels()
 {
-	local list = GSCargoList();
-	for(local i = 0; i < 64; ++i) {
-		Log.Info("Cargo " + i + ": " + GSCargo.GetCargoLabel(i), Log.LVL_SUB_DECISIONS);
+	foreach (index, cargo_label in ::CargoIDList) {
+		Log.Info("Cargo " + index + ": " + cargo_label, Log.LVL_SUB_DECISIONS);
 	}
 }
 


### PR DESCRIPTION
**Added algorith for creating default cargo categories:**
- now all industry NewGRF types are supported
- the cargo types are divided into raw and other (based on industry type that produces the cargo type)
- if there are more than 10 cargo types in the type (raw/other), it will create two categories, otherwise it will be one category
- for two categories per type, the cargo types are devided randomly equally between these categories
- allows for creating 3, 4, 5 number of categories based on number of cargo types
- first category is allways PASS (0) and MAIL (2)

Closes #5 