### PR TITLE
Implemented industry stabilizer

### DIFF
--- a/info.nut
+++ b/info.nut
@@ -98,8 +98,8 @@ class MainClass extends GSInfo
 
 		AddSetting({ name = "raw_industry_density",
 				description = "Industry stabilizer: raw industry density",
-				easy_value = 5,
-				medium_value = 3,
+				easy_value = 0,
+				medium_value = 0,
 				hard_value = 0,
 				custom_value = 0,
 				flags = CONFIG_INGAME, min_value = 0, max_value = 5});

--- a/info.nut
+++ b/info.nut
@@ -96,6 +96,21 @@ class MainClass extends GSInfo
 				custom_value = 0,
 				flags = CONFIG_BOOLEAN});
 
+		AddSetting({ name = "raw_industry_density",
+				description = "Industry stabilizer: raw industry density",
+				easy_value = 5,
+				medium_value = 3,
+				hard_value = 0,
+				custom_value = 0,
+				flags = CONFIG_INGAME, min_value = 0, max_value = 5});
+		AddLabels("raw_industry_density", { 
+					_0 = "Funding only",
+					_1 = "Minimal",
+					_2 = "Very Low",
+					_3 = "Low",
+					_4 = "Normal",
+					_5 = "High"	});
+
 		AddSetting({
 			name = "limit_min_transport",
 			description = "Limit Growth: Minimun percentage of transported cargo from town",

--- a/main.nut
+++ b/main.nut
@@ -64,7 +64,7 @@ class MainClass extends GSController
 function MainClass::Start()
 {
 	// Wait random number of ticks (less than one day) based on system time to ensure random number seed
-	local sysdate = GSDate.GetSystemTime() % 70;
+	local sysdate = GSDate.GetSystemTime() % 70 + 1;
     this.Sleep(sysdate);
 
 	// Initializing the script
@@ -162,6 +162,10 @@ function MainClass::Init()
 	// Create the towns list
 	Log.Info("Create town list ... (can take a while on large maps)", Log.LVL_INFO);
 	this.towns = this.CreateTownList();
+
+	// Run industry stabilizer
+	Log.Info("Prospecting raw industries ... (can take a while on large maps)", Log.LVL_INFO);
+	ProspectRawIndustry();
 
 	// Ending initialization
 	this.gs_init_done = true;
@@ -322,12 +326,16 @@ function MainClass::ManageTowns()
 	}
 
 	// Run the yearly functions - Nothing to do for now, so we leave it out
-	/*local year = GSDate.GetYear(date);
+	local year = GSDate.GetYear(date);
 	local diff_year = year - this.current_year;
-	if ( diff_year == 0) return;
+	if ( diff_year == 0)
+		return;
 	else
 	{
 		GSLog.Info("Starting Yearly Updates");
+
+		ProspectRawIndustry();
+
 		this.current_year = year
-	}*/
+	}
 }


### PR DESCRIPTION
Maintain at least a set number of raw industries on the map:
- executed during initialization and every year
- prospects raw industries on the map so that there are same numbers of each industry type
- the number of industries uses OpenTTD industry density values (number of raw industries that would be expected to be built during world generation on that map size)
- allows for creating maps with only raw industries

![IndustryStabilizer](https://user-images.githubusercontent.com/22470227/104816606-93fb9880-581c-11eb-93a8-07c5b5f6b4d0.PNG)
