### PR TITLE
Allow changing all GS settings

### DIFF
--- a/info.nut
+++ b/info.nut
@@ -53,7 +53,7 @@ class MainClass extends GSInfo
 				medium_value = 1,
 				hard_value = 1,
 				custom_value = 1,
-				flags = CONFIG_BOOLEAN });
+				flags = CONFIG_BOOLEAN | CONFIG_INGAME });
 				
 		AddSetting({ name = "eternal_love",
 				description = "Eternal love from towns",
@@ -73,7 +73,7 @@ class MainClass extends GSInfo
 				medium_value = 2,
 				hard_value = 3,
 				custom_value = 11,
-				flags = CONFIG_NONE, min_value = 1, max_value = 12 });
+				flags = CONFIG_INGAME, min_value = 1, max_value = 12 });
 		AddLabels("cargo_randomization", { 
 					_1 = "None",
 					_2 = "Industry",
@@ -94,7 +94,7 @@ class MainClass extends GSInfo
 				medium_value = 0,
 				hard_value = 0,
 				custom_value = 0,
-				flags = CONFIG_BOOLEAN});
+				flags = CONFIG_BOOLEAN | CONFIG_INGAME});
 
 		AddSetting({ name = "raw_industry_density",
 				description = "Industry stabilizer: raw industry density",

--- a/main.nut
+++ b/main.nut
@@ -54,10 +54,7 @@ class MainClass extends GSController
 		this.actual_town_info_mode = 0;
 		this.toy_lib = null;
 		::TownDataTable <- {};
-		::SettingsTable <- {
-			use_town_sign = GSController.GetSetting("use_town_sign"),
-			randomization = GSController.GetSetting("cargo_randomization")
-		}
+		::SettingsTable <- {};
 	}
 }
 
@@ -138,6 +135,11 @@ function MainClass::Init()
 	GSGameSettings.SetValue("economy.town_growth_rate", 2);
 	GSGameSettings.SetValue("economy.fund_buildings", 0);
 
+	if (!this.load_saved_data) { // Disallow changing these in a running game
+		::SettingsTable.use_town_sign <- GSController.GetSetting("use_town_sign");
+		::SettingsTable.randomization <- GSController.GetSetting("cargo_randomization");
+	}
+
 	// Set current date
 	this.current_date = this.current_week = GSDate.GetCurrentDate();
 	this.current_month = GSDate.GetMonth(this.current_date);
@@ -197,14 +199,9 @@ function MainClass::Save()
 	Log.Info("Saving data...", Log.LVL_INFO);
 	local save_table = {};
 
-	/* If some permanent setting has been changed in scenario
-	 * editor, do not save anything.
-	 */
-	if ((::SettingsTable.use_town_sign != GSController.GetSetting("use_town_sign")) ||
-		(::SettingsTable.randomization != GSController.GetSetting("cargo_randomization"))) {
-		Log.Info("Some permanent setting changed. Not saving town data.", Log.LVL_INFO);
-		return save_table;
-	}
+	// Save permanent settings (allows changing them in scenario editor)
+	save_table.use_town_sign <- ::SettingsTable.use_town_sign;
+	save_table.randomization <- ::SettingsTable.randomization;
 
 	/* If the script isn't yet initialized, we can't retrieve data
 	 * from GoalTown instances. Thus, simply use the original
@@ -231,6 +228,8 @@ function MainClass::Load(version, saved_data)
 	// Loading town data. Only load data if the savegame version matches.
 	if ((saved_data.rawin("save_version") && saved_data.save_version == this.current_save_version)) {
 		this.load_saved_data = true;
+		::SettingsTable.use_town_sign <- saved_data.use_town_sign;
+		::SettingsTable.randomization <- saved_data.randomization;
 		foreach (townid, town_data in saved_data.town_data_table) {
 			::TownDataTable[townid] <- town_data;
 		}

--- a/town.nut
+++ b/town.nut
@@ -374,7 +374,7 @@ function GoalTown::EternalLove(rating)
 function GoalTown::UpdateSignText()
 {
 	// Add a sign by the town to display the current growth
-	if (GSController.GetSetting("use_town_sign")) {
+	if (::SettingsTable.use_town_sign) {
 		local sign_text = TownSignText();
 		if (GSSign.IsValidSign(this.sign_id)) {
 			GSSign.SetName(this.sign_id, sign_text);
@@ -387,7 +387,7 @@ function GoalTown::UpdateSignText()
 function GoalTown::RemoveSignText()
 {
 	// Cleaning signs on the map
-	if (GSController.GetSetting("use_town_sign") && GSSign.IsValidSign(this.sign_id)) {
+	if (::SettingsTable.use_town_sign && GSSign.IsValidSign(this.sign_id)) {
 		GSSign.RemoveSign(this.sign_id);
 		this.sign_id = -1;
 	}


### PR DESCRIPTION
Allow changing all GS settings:
- all settings have flag CONFIG_INGAME
- changing `randomization` and `use_town_sign` in a running game will be ignored