### PR TITLE
Issue warning for too many towns to save

### DIFF
--- a/lang/english.txt
+++ b/lang/english.txt
@@ -34,6 +34,8 @@ STR_SB_CARGOCAT_1        :{STRING} {NUM}: {GREEN}{STRING}{BLACK}{}{STRING}: {SIL
 STR_SB_CARGOCAT_2        :{STRING} {NUM}: {RED}{STRING}{BLACK}{}{STRING}: {SILVER}{NUM}{BLACK} {STRING}: {SILVER}{NUM}%{BLACK}{}{STRING}: {CARGO_LIST}
 STR_SB_CARGOCAT_3        :{STRING} {NUM}: {BROWN}{STRING}{BLACK}{}{STRING}: {SILVER}{NUM}{BLACK} {STRING}: {SILVER}{NUM}%{BLACK}{}{STRING}: {CARGO_LIST}
 STR_SB_CARGOCAT_4        :{STRING} {NUM}: {PURPLE}{STRING}{BLACK}{}{STRING}: {SILVER}{NUM}{BLACK} {STRING}: {SILVER}{NUM}%{BLACK}{}{STRING}: {CARGO_LIST}
+STR_SB_WARNING_TITLE     :Warning
+STR_SB_WARNING_1         :There are more towns on the map than the game script can save. The current number of towns is {SILVER}{NUM}{BLACK} and the maximum is {SILVER}{NUM}{BLACK}. The game script is turned off.
 
 ##### TOWNBOX #####
 STR_TOWNBOX_CATEGORY            :Cargo information: supplied / required{STRING}

--- a/main.nut
+++ b/main.nut
@@ -92,7 +92,7 @@ function MainClass::Start()
 
 	// Create and fill StoryBook. This can't be done before OTTD is ready.
 	local story_editor = StoryEditor();
-	story_editor.CreateStoryBook();
+	story_editor.CreateStoryBook(this.towns.len());
 
 	if (!this.gs_init_done) {
 		GSLog.Error("Game initialisation failed, stopping the game script!");
@@ -164,6 +164,8 @@ function MainClass::Init()
 	// Create the towns list
 	Log.Info("Create town list ... (can take a while on large maps)", Log.LVL_INFO);
 	this.towns = this.CreateTownList();
+	if (this.towns.len() > SELF_MAX_TOWNS)
+		return;
 
 	// Run industry stabilizer
 	Log.Info("Prospecting raw industries ... (can take a while on large maps)", Log.LVL_INFO);
@@ -211,10 +213,12 @@ function MainClass::Save()
 	if (!this.gs_init_done) {
 		save_table.town_data_table <- ::TownDataTable;
 	} else {
+		local start_opcodes = GSController.GetOpsTillSuspend();
 		foreach (i, town in this.towns)
 		{
 			save_table.town_data_table[town.id] <- town.SavingTownData();
 		}
+		Log.Info("Opcodes per saved town = " + ((start_opcodes - GSController.GetOpsTillSuspend()) / this.towns.len()), Log.LVL_DEBUG);
 		// Also store a savegame version flag
 		save_table.save_version <- this.current_save_version;
 	}

--- a/story.nut
+++ b/story.nut
@@ -82,19 +82,28 @@ function StoryEditor::CargoInfoPage()
 	}
 }
 
+/* Issue an initial warning if game's cargo list doesn't match with settings. */
+function StoryEditor::TownsWarningPage(num_towns)
+{
+	// Creating the page
+	local sp_warning = this.NewStoryPage(GSCompany.COMPANY_INVALID, GSText(GSText.STR_SB_WARNING_TITLE));
+	GSStoryPage.NewElement(sp_warning, GSStoryPage.SPET_TEXT, 0, GSText(GSText.STR_SB_WARNING_1, num_towns, SELF_MAX_TOWNS));
+	GSStoryPage.Show(sp_warning);
+}
+
 /* Create the StoryBook if it still doesn't exist. This function is
  * called only when (re)initializing all data, because the existing
  * storybook is stored by OTTD.
  */
-function StoryEditor::CreateStoryBook()
+function StoryEditor::CreateStoryBook(num_towns)
 {
 	// Remove any eventual previous existent storypage
 	local sb_list = GSStoryPageList(0);
 	foreach (page, _ in sb_list) GSStoryPage.Remove(page);
 
-	// Issue a warning if industry set doesn't match
-	if (!::CargoIDList) {
-		this.CargoWarningPage();
+	// Issue a warning if there are more towns on the map than the GS can save
+	if (num_towns > SELF_MAX_TOWNS) {
+		this.TownsWarningPage(num_towns);
 	}
 	// Create basic cargo informations page (randomization industry does not support cargo info page)
 	else if (::SettingsTable.randomization != Randomization.INDUSTRY) {

--- a/version.nut
+++ b/version.nut
@@ -3,3 +3,4 @@ SELF_MINLOADVERSION <- 6        // minimum integer version of GS that can load t
 SELF_MAJORVERSION <- 5          // main version of the GS, releases with same major version should be saveload compatible
 SELF_MINORVERSION <- 0          // minor version of the GS, incremental subreleases of the major version, saveload compatible
 SELF_DATE <- "2020-11-24"       // release date
+SELF_MAX_TOWNS <- 1500          // maximum number of towns that can be successfully saved in this release


### PR DESCRIPTION
Saving can take up to 100000 opcodes, so there is finite number of towns the GS can save. (currently 1500 with 65 opcodes per town) When there are more towns than the limit, a warning is issued and the GS is disabled.