### PR TITLE
fixed zero growth rate

### DIFF
--- a/town.nut
+++ b/town.nut
@@ -214,6 +214,7 @@ function GoalTown::MonthlyManageTown()
 	this.DebugGoalsResult(sum_goals, goal_diff, goal_diff_percent);  // Debug info about general goal results
 	if (goal_diff_percent <= sup_imp_part) {
 		local max_town_growth_rate = g_factor * 50000 / (100 + cur_pop.tofloat());
+		max_town_growth_rate = max_town_growth_rate > 1 ? max_town_growth_rate : 1;
 		new_town_growth_rate = (max_town_growth_rate
 					* (1 + (e_factor / (1 - goal_diff_percent * 2) - e_factor))).tointeger();
 	} else if (goal_diff_percent > sup_imp_part || new_town_growth_rate > lowest_tgr) {


### PR DESCRIPTION
The growth rate is limited to 1 day minimum so there is no expoding growth of towns, which could be achieved by using very easy parameters.