### PR TITLE
Fixes in FIRS4 Steeltowns cargoes

### DIFF
--- a/cargo.nut
+++ b/cargo.nut
@@ -718,8 +718,8 @@ function DefineCargosBySettings(economy)
             ::CargoCat <- [[0,2],
                        [11,13,21,22,25,32,33,34,36,47],
                        [4,12,16,19,24,26,29,31,46],
-                       [1,3,6,7,8,10,14,15,17,18,20,23,27,28,30,35,37,38,39,40,41],
-                       [5,9,42,43,44,45]];
+                       [1,3,6,7,8,10,14,15,17,18,20,23,27,30,35,37,38,39,40,41],
+                       [5,9,28,42,43,44,45]];
             ::CargoCatList <- [CatLabels.PUBLIC_SERVICES,CatLabels.LOCAL_PRODUCTION,CatLabels.IMPORTED_GOODS,
                        CatLabels.PROCESSED_MATERIALS,CatLabels.FINAL_PRODUCTS];
             ::CargoMinPopDemand <- [0,500,1000,4000,8000];

--- a/cargo.nut
+++ b/cargo.nut
@@ -718,8 +718,8 @@ function DefineCargosBySettings(economy)
             ::CargoCat <- [[0,2],
                        [11,13,21,22,25,32,33,34,36,47],
                        [4,12,16,19,24,26,29,31,46],
-                       [1,3,6,7,8,10,14,15,17,18,20,23,27,30,35,37,38,39,40,41],
-                       [5,9,28,42,43,44,45]];
+                       [1,3,6,7,8,10,14,15,17,18,20,23,27,30,35,37,39,40,41],
+                       [5,9,28,38,42,43,44,45]];
             ::CargoCatList <- [CatLabels.PUBLIC_SERVICES,CatLabels.LOCAL_PRODUCTION,CatLabels.IMPORTED_GOODS,
                        CatLabels.PROCESSED_MATERIALS,CatLabels.FINAL_PRODUCTS];
             ::CargoMinPopDemand <- [0,500,1000,4000,8000];

--- a/cargo.nut
+++ b/cargo.nut
@@ -718,8 +718,8 @@ function DefineCargosBySettings(economy)
             ::CargoCat <- [[0,2],
                        [11,13,21,22,25,32,33,34,36,47],
                        [4,12,16,19,24,26,29,31,46],
-                       [1,3,6,7,8,10,14,15,17,18,20,23,27,29,30,35,37,38,39,40,41],
-                       [5,9,28,28,42,43,44,45]];
+                       [1,3,6,7,8,10,14,15,17,18,20,23,27,28,30,35,37,38,39,40,41],
+                       [5,9,42,43,44,45]];
             ::CargoCatList <- [CatLabels.PUBLIC_SERVICES,CatLabels.LOCAL_PRODUCTION,CatLabels.IMPORTED_GOODS,
                        CatLabels.PROCESSED_MATERIALS,CatLabels.FINAL_PRODUCTS];
             ::CargoMinPopDemand <- [0,500,1000,4000,8000];


### PR DESCRIPTION
Removed duplicated PLAS (produced by bulk terminal so should be imported goods, but was both imported goods and processed materials)
Moved duplicated PIPE from final products to processed materials