### PR TITLE
Fix: Minimum fulfilled percentage for TGR growth

### DIFF
--- a/info.nut
+++ b/info.nut
@@ -115,7 +115,7 @@ class MainClass extends GSInfo
         AddSetting({
             name = "limit_min_transport",
             description = "Limit Growth: Minimum percentage of transported cargo from town",
-            easy_value = 30,
+            easy_value = 40,
             medium_value = 50,
             hard_value = 65,
             custom_value = 50,
@@ -150,10 +150,10 @@ class MainClass extends GSInfo
                 flags = CONFIG_INGAME, min_value = 20, max_value = 1000, step_size = 20 });
 
         AddSetting({ name = "supply_impacting_part",
-                description = "Expert: minimum missing percentage for TGR growth",
-                easy_value = 20,
+                description = "Expert: minimum fulfilled percentage for TGR growth",
+                easy_value = 30,
                 medium_value = 50,
-                hard_value = 80,
+                hard_value = 70,
                 custom_value = 50,
                 flags = CONFIG_INGAME, min_value = 0, max_value = 100, step_size = 5 });
 

--- a/readme.txt
+++ b/readme.txt
@@ -215,8 +215,8 @@ they can safely be changed while the game is running:
   rate of a town. Increasing it will result in slower town growth
   and decreasing it will result in faster town growth. The value
   represents the maximum town growth at 0 population.
-- "minimum missing percentage for TGR growth": this value specifies the
-  minimum missing percentage of fulfillment of cargo categories for which 
+- "minimum fulfilled percentage for TGR growth": this value specifies the
+  minimum fulfillment percentage of cargo categories for which 
   the growth rate is calculated. When this percentage is not fulfilled, 
   the lowest growth rate is used. The growth is still scaled to 100% of 
   the fulfillment. 

--- a/town.nut
+++ b/town.nut
@@ -237,7 +237,7 @@ function GoalTown::MonthlyManageTown()
     // The max growth rate and difference between max growth rate and lowest growth rate
     // multiplied by extra growth factor are combined into the resulting growth rate.
     Log.Info("Goal diff: " + goal_diff_percent + "%", Log.LVL_DEBUG);
-    if (goal_diff_percent <= sup_imp_part) {
+    if ((1.0 - goal_diff_percent) >= sup_imp_part) {
         local max_town_growth_rate = g_factor * exp(-cur_pop.tofloat()/10000);
         max_town_growth_rate = max_town_growth_rate < 1 ? 1 : max_town_growth_rate;
         local growth = 1 - (1 - exp(-e_factor * (1 - goal_diff_percent))) / (1 - exp(-e_factor));


### PR DESCRIPTION
Changed parameter "minimum missing percentage for TGR growth" to "minimum fulfilled percentage for TGR growth". Now 30 means the categories have to be fulfilled at least to 30% (with 3 categories, it is enough to fully supply one category).

Closes https://github.com/F1rrel/RenewedVillageGrowth/issues/75