### PR TITLE
New: added category and zero growth settings

### DIFF
--- a/cargo.nut
+++ b/cargo.nut
@@ -842,6 +842,35 @@ function CompareCargoLists(list1, list2) {
     return true;
 }
 
+function SortCategoriesMinPopDemand()
+{
+    for (local i = 0; i < ::CargoCatNum; i++) {
+        for (local j = 0; j < ::CargoCatNum - 1; j++) {
+            if (::CargoMinPopDemand[j] > ::CargoMinPopDemand[j+1]) {
+                local cargo_cat = ::CargoCat[j];
+                ::CargoCat[j] = ::CargoCat[j+1];
+                ::CargoCat[j+1] = cargo_cat;
+
+                local cargo_cat_list = ::CargoCatList[j];
+                ::CargoCatList[j] = ::CargoCatList[j+1];
+                ::CargoCatList[j+1] = cargo_cat_list;
+
+                local min_pop_demand = ::CargoMinPopDemand[j];
+                ::CargoMinPopDemand[j] = ::CargoMinPopDemand[j+1];
+                ::CargoMinPopDemand[j+1] = min_pop_demand;
+
+                local cargo_permille = ::CargoPermille[j];
+                ::CargoPermille[j] = ::CargoPermille[j+1];
+                ::CargoPermille[j+1] = cargo_permille;
+
+                local cargo_decay = ::CargoDecay[j];
+                ::CargoDecay[j] = ::CargoDecay[j+1];
+                ::CargoDecay[j+1] = cargo_decay;
+            }
+        }
+    }
+}
+
 /* Initialization of cargo data. */
 function InitCargoLists()
 {
@@ -863,6 +892,18 @@ function InitCargoLists()
     ::CargoCatNum <- ::CargoCat.len();
     ::Economy <- economy;
 
+    // Change cargo min pop demand if specified
+    local changed_min_pop_demand = false;
+    foreach (i, min_pop in ::SettingsTable.category_min_pop) {
+        if (min_pop > 0) {
+            ::CargoMinPopDemand[i] = min_pop;
+            changed_min_pop_demand = true;
+        }
+    }
+
+    if (changed_min_pop_demand)
+        SortCategoriesMinPopDemand();
+
     return true;
 }
 
@@ -872,7 +913,7 @@ function RandomizeFixed(number)
     local cargo_cat = array(::CargoCat.len());
     foreach (cat_idx, cat in ::CargoCat)
     {
-        if (cat_idx == 0) {
+        if (::CargoCatList[cat_idx] == CatLabels.PUBLIC_SERVICES || ::CargoCatList[cat_idx] == CatLabels.CATEGORY_I) {
             cargo_cat[cat_idx] = cat;
         } else {
             local cargo_list = clone cat;
@@ -894,7 +935,7 @@ function RandomizeRange(lower, upper)
     local cargo_cat = array(::CargoCat.len());
     foreach (cat_idx, cat in ::CargoCat)
     {
-        if (cat_idx == 0) {
+        if (::CargoCatList[cat_idx] == CatLabels.PUBLIC_SERVICES || ::CargoCatList[cat_idx] == CatLabels.CATEGORY_I) {
             cargo_cat[cat_idx] = cat;
         } else {
             local cargo_list = clone cat;

--- a/info.nut
+++ b/info.nut
@@ -141,6 +141,51 @@ class MainClass extends GSInfo
             custom_value = 1,
             flags = CONFIG_INGAME, min_value = 0, max_value = 12, step_size = 1});
 
+        AddSetting({
+            name = "category_1_min_pop",
+            description = "Category 1: Minimum population demand (0 = default)",
+            easy_value = 0,
+            medium_value = 0,
+            hard_value = 0,
+            custom_value = 0,
+            flags = CONFIG_INGAME, min_value = 0, max_value = 50000, step_size = 100});
+        
+        AddSetting({
+            name = "category_2_min_pop",
+            description = "Category 2: Minimum population demand (0 = default)",
+            easy_value = 0,
+            medium_value = 0,
+            hard_value = 0,
+            custom_value = 0,
+            flags = CONFIG_INGAME, min_value = 0, max_value = 50000, step_size = 100});
+        
+        AddSetting({
+            name = "category_3_min_pop",
+            description = "Category 3: Minimum population demand (0 = default)",
+            easy_value = 0,
+            medium_value = 0,
+            hard_value = 0,
+            custom_value = 0,
+            flags = CONFIG_INGAME, min_value = 0, max_value = 50000, step_size = 100});
+        
+        AddSetting({
+            name = "category_4_min_pop",
+            description = "Category 4: Minimum population demand (0 = default)",
+            easy_value = 0,
+            medium_value = 0,
+            hard_value = 0,
+            custom_value = 0,
+            flags = CONFIG_INGAME, min_value = 0, max_value = 50000, step_size = 100});
+
+        AddSetting({
+            name = "category_5_min_pop",
+            description = "Category 5: Minimum population demand (0 = default)",
+            easy_value = 0,
+            medium_value = 0,
+            hard_value = 0,
+            custom_value = 0,
+            flags = CONFIG_INGAME, min_value = 0, max_value = 50000, step_size = 100});
+
         AddSetting({ name = "town_growth_factor",
                 description = "Expert: town growth factor",
                 easy_value = 50,
@@ -172,6 +217,14 @@ class MainClass extends GSInfo
                 hard_value = 880,
                 custom_value = 550,
                 flags = CONFIG_INGAME, min_value = 10, max_value = 880, step_size = 10 });
+
+        AddSetting({ name = "allow_0_days_growth",
+                description = "Expert: allow 0 days growth",
+                easy_value = 0,
+                medium_value = 0,
+                hard_value = 0,
+                custom_value = 0,
+                flags = CONFIG_BOOLEAN | CONFIG_INGAME});
 
         AddSetting({ name = "log_level",
                 description = "Debug: Log level (higher = print more)",

--- a/main.nut
+++ b/main.nut
@@ -146,6 +146,11 @@ function MainClass::Init()
         ::SettingsTable.use_town_sign <- GSController.GetSetting("use_town_sign");
         ::SettingsTable.randomization <- GSController.GetSetting("cargo_randomization");
         ::SettingsTable.display_cargo <- GSController.GetSetting("display_cargo");
+        ::SettingsTable.category_min_pop <- [GSController.GetSetting("category_1_min_pop"),
+                                             GSController.GetSetting("category_2_min_pop"),
+                                             GSController.GetSetting("category_3_min_pop"),
+                                             GSController.GetSetting("category_4_min_pop"),
+                                             GSController.GetSetting("category_5_min_pop")];
     }
 
     // Set current date
@@ -234,6 +239,7 @@ function MainClass::Save()
         save_table.use_town_sign <- ::SettingsTable.use_town_sign;
         save_table.randomization <- ::SettingsTable.randomization;
         save_table.display_cargo <- ::SettingsTable.display_cargo;
+        save_table.category_min_pop <- ::SettingsTable.category_min_pop;
 
         foreach (company in this.companies)
         {
@@ -262,6 +268,7 @@ function MainClass::Load(version, saved_data)
         ::SettingsTable.use_town_sign <- saved_data.use_town_sign;
         ::SettingsTable.randomization <- saved_data.randomization;
         ::SettingsTable.display_cargo <- saved_data.display_cargo;
+        ::SettingsTable.category_min_pop <- saved_data.category_min_pop;
 
         foreach (companyid, company_data in saved_data.company_data_table) {
             ::CompanyDataTable[companyid] <- company_data;

--- a/readme.txt
+++ b/readme.txt
@@ -204,6 +204,13 @@ Limit growth settings:
 - "Stop growth after set amount of months": keep growing for the amount
   of months after limiter stops the growth
 
+Category settings:
+These settings change the cargo category values and can only be changed
+before the game start.
+- "category_X_min_pop": change the minimum population at which the demand
+  for that category starts. The categories are sorted based on selected
+  values. Choosing value 0 uses the economy's default value.
+
 Expert settings:
 These settings are for people who want finely tweak the script
 behaviour. Most people shouldn't change them and can just change

--- a/readme.txt
+++ b/readme.txt
@@ -239,6 +239,7 @@ they can safely be changed while the game is running:
   disabling completely town growth but setting it to an extremely low
   rate. The default is 880 (which means that a new house is created
   only each 880 days). It can be increased until 880.
+- "allow_0_days_growth": the town growth rate can go to zero.
 
 
 3. Requirements

--- a/story.nut
+++ b/story.nut
@@ -171,14 +171,14 @@ function StoryEditor::CreateStoryBook(companies, num_towns)
     foreach (page, _ in sb_list) GSStoryPage.Remove(page);
 
     foreach (company in companies) {
+        // Create basic cargo informations page
+        company.sp_cargo = this.NewStoryPage(company.id, GSText(GSText.STR_SB_TITLE_1));
+        this.CargoInfoPage(company.sp_cargo);
+
         // Create welcome page
         company.sp_welcome = this.NewStoryPage(company.id, GSText(GSText.STR_SB_WELCOME_TITLE, SELF_MAJORVERSION, SELF_MINORVERSION));
         this.WelcomePage(company.sp_welcome);
         GSStoryPage.Show(company.sp_welcome);
-
-        // Create basic cargo informations page
-        company.sp_cargo = this.NewStoryPage(company.id, GSText(GSText.STR_SB_TITLE_1));
-        this.CargoInfoPage(company.sp_cargo);
     }
 
     // Issue a warning if there are more towns on the map than the GS can save
@@ -191,14 +191,14 @@ function StoryEditor::CreateStoryBook(companies, num_towns)
 
 function StoryEditor::CreateNewCompanyStoryBook(company)
 {
+    // Create basic cargo informations page
+    company.sp_cargo = this.NewStoryPage(company.id, GSText(GSText.STR_SB_TITLE_1));
+    this.CargoInfoPage(company.sp_cargo);
+
     // Create welcome page
     company.sp_welcome = this.NewStoryPage(company.id, GSText(GSText.STR_SB_WELCOME_TITLE, SELF_MAJORVERSION, SELF_MINORVERSION));
     this.WelcomePage(company.sp_welcome);
     GSStoryPage.Show(company.sp_welcome);
-
-    // Create basic cargo informations page
-    company.sp_cargo = this.NewStoryPage(company.id, GSText(GSText.STR_SB_TITLE_1));
-    this.CargoInfoPage(company.sp_cargo);
 }
 
 /* Wrapper that creates a new StoryPage but disable date output. */

--- a/strings.nut
+++ b/strings.nut
@@ -9,20 +9,25 @@ function GoalTown::TownBoxText(growth_enabled, text_mode, redraw=false)
         if (display_cargo) {
             text_townbox = GSText(GSText["STR_TOWNBOX_CARGO_"+(::CargoCatNum-1)]);
             text_townbox = this.TownTextContributor(text_townbox);
+            
+            local cargo_mask = 0;
+            foreach (cargo in ::CargoLimiter) {
+                cargo_mask = cargo_mask | 1 << cargo;
+            }
+            text_townbox.AddParam(GSText(GSText.STR_TOWNBOX_NOGROWTH, cargo_mask));
+
             foreach (index, category in this.town_cargo_cat) {
-                local cargo_mask = 0;
+                cargo_mask = 0;
                 foreach (cargo in category) {
-                    cargo_mask += 1 << cargo;
+                    cargo_mask = cargo_mask | 1 << cargo;
                 }
-                if (index == 0)
-                    text_townbox.AddParam(GSText(GSText.STR_TOWNBOX_NOGROWTH, cargo_mask));
                 text_townbox.AddParam(GSText(GSText["STR_CARGOCAT_LABEL_"+::CargoCatList[index]]));
                 text_townbox.AddParam(cargo_mask);
             }
         } else {
             local cargo_mask = 0;
-            foreach (cargo in this.town_cargo_cat[0]) {
-                cargo_mask += 1 << cargo;
+            foreach (cargo in ::CargoLimiter) {
+                cargo_mask = cargo_mask | 1 << cargo;
             }
             text_townbox = GSText(GSText.STR_TOWNBOX_NOGROWTH, cargo_mask);
         }

--- a/town.nut
+++ b/town.nut
@@ -141,6 +141,7 @@ function GoalTown::MonthlyManageTown()
     local e_factor = GSController.GetSetting("exponentiality_factor");
     local sup_imp_part = GSController.GetSetting("supply_impacting_part") / 100.0;
     local lowest_tgr = GSController.GetSetting("lowest_town_growth_rate");
+    local allow_0_days_growth = GSController.GetSetting("allow_0_days_growth");
     // Clearing the arrays
     this.town_supplied_cat = array(::CargoCatNum, 0);
     this.town_goals_cat = array(::CargoCatNum, 0);
@@ -250,7 +251,7 @@ function GoalTown::MonthlyManageTown()
 
     if (new_town_growth_rate > lowest_tgr)
         new_town_growth_rate = lowest_tgr;
-    else if (new_town_growth_rate < 1)
+    else if (new_town_growth_rate < 1 && !allow_0_days_growth)
         new_town_growth_rate = 1;
 
     // Defining the new town growth rate, calculated as the moving average of the TGR array, update only if town growth requirements are fulfilled
@@ -366,7 +367,7 @@ function GoalTown::CheckMonitoring(monitored)
     local delivery_check = 0;
     for (local cid = GSCompany.COMPANY_FIRST; cid <= GSCompany.COMPANY_LAST; cid++) {
         if (GSCompany.ResolveCompanyID(cid) != GSCompany.COMPANY_INVALID) {
-            foreach (cargo in town_cargo_cat[0]) {
+            foreach (cargo in ::CargoLimiter) {
                 delivery_check += GSCargoMonitor.GetTownPickupAmount(cid, cargo, this.id, true);
                 if (delivery_check > 0) break;
             }


### PR DESCRIPTION
Added new settings:

"category_X_min_pop": change the minimum population at which the demand for that category starts. The categories are sorted based on selected values. Choosing value 0 uses the economy's default value.

"allow_0_days_growth": the town growth rate can go to zero.