### PR TITLE
Fix: Cargo and industry lists

### DIFF
--- a/cargo.nut
+++ b/cargo.nut
@@ -130,7 +130,8 @@ function GetEconomyCargoList(economy, cargo_list) {
         local list = ["PASS","GRVL","MAIL","WOOD","BDMT",  null,"GRAI","FRUT","FOOD",  null,
                       "OIL_",  null,"STEL","PETR","BATT","VEHI","YETI","CLAY","LVST","URAN",
                       "IORE"];
-        list.append((cargo_list[21] == "YETY") ? "YETY" : null);
+        if (21 < cargo_list.len() && cargo_list[21] == "YETY")
+            list.append("YETY");
         return list;
     }
     /* FIRS version 3 */
@@ -165,11 +166,20 @@ function GetEconomyCargoList(economy, cargo_list) {
     {
         local list = ["PASS","COAL","MAIL","OIL_","WDPR","GOOD","RFPR","WOOD","IORE","STEL",
                         null,  null,"FOOD",  null,  null,  null];
-        list[10] = ((cargo_list[10] == "RCYC") ? "RCYC" : null);
-        list[11] = ((cargo_list[11] == "WSTE") ? "WSTE" : null);
-        list[13] = ((cargo_list[13] == "URAN") ? "URAN" : null);
-        list[14] = ((cargo_list[14] == "NUKF") ? "NUKF" : null);
-        list[15] = ((cargo_list[15] == "NUKW") ? "NUKW" : null);
+
+        list[10] = ((10 < cargo_list.len() && cargo_list[10] == "RCYC") ? "RCYC" : null);
+        list[11] = ((11 < cargo_list.len() && cargo_list[11] == "WSTE") ? "WSTE" : null);
+        list[13] = ((13 < cargo_list.len() && cargo_list[13] == "URAN") ? "URAN" : null);
+        list[14] = ((14 < cargo_list.len() && cargo_list[14] == "NUKF") ? "NUKF" : null);
+        list[15] = ((15 < cargo_list.len() && cargo_list[15] == "NUKW") ? "NUKW" : null);
+
+        // Remove null cargo types at the end of the list
+        local index = 15;
+        while (list[index] == null) {
+            list.remove(index);
+            --index;
+        }
+
         return list;
     }
     /* FIRS version 4.3 */
@@ -208,7 +218,7 @@ function GetEconomyCargoList(economy, cargo_list) {
                       "RUBR","VEHI","BAKE","PIPE","OYST","MEAT","CHSE","FURN","TEXT","SEED",
                       "FERT","BOOM","ACID","CHLO","SLAG","TWOD","SESP","FUEL","ELTR","WATR",
                       "TATO","POWR","MPTS","RFPR"];
-        if (cargo_list[60] == "POTA")
+        if (60 < cargo_list.len() && cargo_list[60] == "POTA")
             list[60] = "POTA";
         return list;
         
@@ -271,7 +281,7 @@ function ConstructECSVectorCargoList(cargo_list) {
     local basic_list = ["COAL","SAND","GLAS","BDMT"];
     local basic_idx = [1,17,18,28];
     foreach (index, id in basic_idx) {
-        if (cargo_list[id] != basic_list[index]) {
+        if (basic_idx[index] >= cargo_list.len() || cargo_list[id] != basic_list[index]) {
             basic = false;
             break;
         }
@@ -288,7 +298,7 @@ function ConstructECSVectorCargoList(cargo_list) {
     local chemical_list = ["OIL_","DYES","RFPR","PETR"];
     local chemical_idx = [3,20,23,25];
     foreach (index, id in chemical_idx) {
-        if (cargo_list[id] != chemical_list[index]) {
+        if (basic_idx[index] >= cargo_list.len() || cargo_list[id] != chemical_list[index]) {
             chemical = false;
             break;
         }
@@ -305,7 +315,7 @@ function ConstructECSVectorCargoList(cargo_list) {
     local machinery_list = ["IORE","STEL","VEHI","AORE"];
     local machinery_idx = [8,9,24,26];
     foreach (index, id in machinery_idx) {
-        if (cargo_list[id] != machinery_list[index]) {
+        if (basic_idx[index] >= cargo_list.len() || cargo_list[id] != machinery_list[index]) {
             machinery = false;
             break;
         }
@@ -322,7 +332,7 @@ function ConstructECSVectorCargoList(cargo_list) {
     local wood_list = ["WOOD","PAPR","WDPR"];
     local wood_idx = [7,12,19];
     foreach (index, id in wood_idx) {
-        if (cargo_list[id] != wood_list[index]) {
+        if (basic_idx[index] >= cargo_list.len() || cargo_list[id] != wood_list[index]) {
             wood = false;
             break;
         }
@@ -339,7 +349,7 @@ function ConstructECSVectorCargoList(cargo_list) {
     local agricultural_list = ["LVST","CERE","FOOD","FRUT","FISH","WOOL","FERT","OLSD","FICR"];
     local agricultural_idx = [4,6,11,13,14,15,21,22,29];
     foreach (index, id in agricultural_idx) {
-        if (cargo_list[id] != agricultural_list[index]) {
+        if (basic_idx[index] >= cargo_list.len() || cargo_list[id] != agricultural_list[index]) {
             agricultural = false;
             break;
         }
@@ -349,6 +359,13 @@ function ConstructECSVectorCargoList(cargo_list) {
         foreach (index, id in agricultural_idx) {
             return_list[id] = agricultural_list[index];
         }
+    }
+
+    // Remove null cargo types at the end of the list
+    local index = 63;
+    while (return_list[index] == null) {
+        return_list.remove(index);
+        --index;
     }
     
     return return_list;
@@ -793,7 +810,8 @@ function DefineCargosBySettings(economy)
             ::CargoDecay <- [0.3,0.3,0.3,0.3];
             break;
         default:
-            CreateDefaultCargoCat();
+            if (!CreateDefaultCargoCat())
+                return false;
             break;
     }
 
@@ -801,7 +819,7 @@ function DefineCargosBySettings(economy)
     if (::CargoIDList) {
         foreach (cat in ::CargoCat) {
             for (local index = 0; index < cat.len(); ++index) {
-                if (::CargoIDList[cat[index]] == null) {
+                if (cat[index] >= ::CargoIDList.len() || ::CargoIDList[cat[index]] == null) {
                     cat.remove(index);
                     --index;
                 }
@@ -809,12 +827,14 @@ function DefineCargosBySettings(economy)
         }
 
         foreach (index, cargo in ::CargoLimiter) {
-            if (::CargoIDList[cargo] == null) {
+            if (cargo >= ::CargoIDList.len() || ::CargoIDList[cargo] == null) {
                 ::CargoLimiter.remove(index);
                 --index;
             }
         }
     }
+
+    return true;
 }
 
 /* This function compares the ingame initial cargo list to the
@@ -833,8 +853,10 @@ function DiscoverEconomyType() {
 }
 
 function CompareCargoLists(list1, list2) {
-    local len = (list1.len() > list2.len()) ? list2.len() : list1.len();
-    for (local i = 0; i < len; i++) {
+    if (list1.len() != list2.len())
+        return false;
+
+    for (local i = 0; i < list1.len(); i++) {
         if (list1[i] != list2[i]) {
             return false;
         }
@@ -878,14 +900,33 @@ function InitCargoLists()
     for(local i = 0; i < 64; ++i) {
         if (GSCargo.GetCargoLabel(i) == "LVPT") // CZTR ZBARVENI
             ::CargoIDList.append(null);
+        else if (GSCargo.GetCargoLabel(i) == null) {
+            local j = i + 1;
+            local list_end = true;
+            while (j < 64) {
+                if (GSCargo.GetCargoLabel(j) != null) {
+                    list_end = false;
+                    break;
+                }
+                j++;
+            }
+
+            if (list_end)
+                break;
+            else
+                ::CargoIDList.append(GSCargo.GetCargoLabel(i));
+        }
         else
             ::CargoIDList.append(GSCargo.GetCargoLabel(i));
     }
 
     DebugCargoLabels();         // Debug info: print cargo labels
 
-    local economy = DiscoverEconomyType();  // Get economy type based on cargo list
-    DefineCargosBySettings(economy);        // Define cargo data accordingly to industry set
+    // Get economy type based on cargo list
+    // Define cargo data accordingly to industry set
+    local economy = DiscoverEconomyType();  
+    if (!DefineCargosBySettings(economy))
+        return false;
     Log.Info("Economy: " + (economy == Economies.NONE ? "generated" : ("predefined " + economy)), Log.LVL_INFO);
 
     // Initializing some useful and often used variables
@@ -1153,4 +1194,11 @@ function CreateDefaultCargoCat()
         }
     }
     Log.Info(cargo_text, Log.LVL_SUB_DECISIONS);
+
+    foreach (cat in ::CargoCat) {
+        if (!cat.len())
+            return false;
+    }
+
+    return true;
 }

--- a/lang/english.txt
+++ b/lang/english.txt
@@ -33,7 +33,10 @@ STR_SB_CARGOCAT_2        :{STRING} {NUM} : {RED}{STRING}{BLACK}{}{STRING} : {SIL
 STR_SB_CARGOCAT_3        :{STRING} {NUM} : {BROWN}{STRING}{BLACK}{}{STRING} : {SILVER}{NUM}{BLACK} {STRING} : {SILVER}{NUM}%{BLACK}{}{STRING} : {CARGO_LIST}
 STR_SB_CARGOCAT_4        :{STRING} {NUM} : {PURPLE}{STRING}{BLACK}{}{STRING} : {SILVER}{NUM}{BLACK} {STRING} : {SILVER}{NUM}%{BLACK}{}{STRING} : {CARGO_LIST}
 STR_SB_WARNING_TITLE     :Warning
-STR_SB_WARNING_1         :There are more towns on the map than the game script can save. The current number of towns is {SILVER}{NUM}{BLACK} and the maximum is {SILVER}{NUM}{BLACK}. The game script is turned off.
+STR_SB_WARNING_1         :There are more towns on the map than the game script can save. The current number of towns is {SILVER}{NUM}{BLACK} and the maximum is {SILVER}{NUM}{BLACK}. {RED}The game script is turned off.{BLACK}
+STR_SB_WARNING_2         :The cargo list initialization has failed. It was caused by an unknown industry newGRF for which a procedural cargo list creation was not possible. {RED}The game script is turned off.{BLACK}
+STR_SB_WARNING_3         :The cargo list initialization has failed. It was caused by the industry randomization option for which the procedural industry categories could not be created. {RED}The game script is turned off.{BLACK}
+STR_SB_WARNING_4         :You must set parameter {ORANGE}Environment->Towns->Town growth speed{BLACK} to something other than None. {RED}The game script is turned off.{BLACK}
 STR_SB_WELCOME_TITLE     :Renewed Village Growth {NUM}.{NUM}
 STR_SB_WELCOME_DESC      :{SILVER}Renewed Village Growth (RVG){BLACK} is a game script which {ORANGE}changes the way towns grow{BLACK} in OpenTTD. Various cargo requirements are defined for each town that need to be - partially or completely - monthly satisfied to make the towns grow faster. More information can be found in the {ORANGE}Readme file{BLACK}.
 STR_SB_WELCOME_CARGO     :Economy {SILVER}{STRING}{BLACK} consists of {SILVER}{NUM} categories{BLACK}. To fulfill a category, deliver one or more of the category specific cargos to a {ORANGE}station near the town which accepts that cargo type{BLACK}. Fulfill the requirements above {SILVER}{NUM}%{BLACK} to {ORANGE}make the towns grow faster{BLACK}. More information about cargo categories are shown in the {ORANGE}Cargo categories story book page{BLACK}.

--- a/story.nut
+++ b/story.nut
@@ -153,39 +153,53 @@ function StoryEditor::CargoInfoPage(sp_cargo)
     }
 }
 
-/* Issue an initial warning if game's cargo list doesn't match with settings. */
-function StoryEditor::TownsWarningPage(num_towns)
-{
-    // Creating the page
-    GSStoryPage.NewElement(this.sp_warning, GSStoryPage.SPET_TEXT, 0, GSText(GSText.STR_SB_WARNING_1, num_towns, SELF_MAX_TOWNS));
-}
-
 /* Create the StoryBook if it still doesn't exist. This function is
  * called only when (re)initializing all data, because the existing
  * storybook is stored by OTTD.
  */
-function StoryEditor::CreateStoryBook(companies, num_towns)
+function StoryEditor::CreateStoryBook(companies, num_towns, init_error)
 {
     // Remove any eventual previous existent storypage
     local sb_list = GSStoryPageList(0);
     foreach (page, _ in sb_list) GSStoryPage.Remove(page);
 
-    foreach (company in companies) {
-        // Create basic cargo informations page
-        company.sp_cargo = this.NewStoryPage(company.id, GSText(GSText.STR_SB_TITLE_1));
-        this.CargoInfoPage(company.sp_cargo);
+    if (!init_error) {
+        foreach (company in companies) {
+            // Create basic cargo informations page
+            company.sp_cargo = this.NewStoryPage(company.id, GSText(GSText.STR_SB_TITLE_1));
+            this.CargoInfoPage(company.sp_cargo);
 
-        // Create welcome page
-        company.sp_welcome = this.NewStoryPage(company.id, GSText(GSText.STR_SB_WELCOME_TITLE, SELF_MAJORVERSION, SELF_MINORVERSION));
-        this.WelcomePage(company.sp_welcome);
-        GSStoryPage.Show(company.sp_welcome);
+            // Create welcome page
+            company.sp_welcome = this.NewStoryPage(company.id, GSText(GSText.STR_SB_WELCOME_TITLE, SELF_MAJORVERSION, SELF_MINORVERSION));
+            this.WelcomePage(company.sp_welcome);
+            GSStoryPage.Show(company.sp_welcome);
+        }
     }
 
-    // Issue a warning if there are more towns on the map than the GS can save
-    if (num_towns > SELF_MAX_TOWNS) {
-        this.sp_warning = this.NewStoryPage(GSCompany.COMPANY_INVALID, GSText(GSText.STR_SB_WARNING_TITLE));
-        this.TownsWarningPage(num_towns);
-        GSStoryPage.Show(this.sp_warning);
+    switch (init_error) {
+        // Issue a warning if there are more towns on the map than the GS can save
+        case InitError.TOWN_NUMBER:
+            this.sp_warning = this.NewStoryPage(GSCompany.COMPANY_INVALID, GSText(GSText.STR_SB_WARNING_TITLE));
+            GSStoryPage.NewElement(this.sp_warning, GSStoryPage.SPET_TEXT, 0, GSText(GSText.STR_SB_WARNING_1, num_towns, SELF_MAX_TOWNS));
+            GSStoryPage.Show(this.sp_warning);
+            break;
+        // Issue a warning that the cargo list initialization has failed
+        case InitError.CARGO_LIST:
+            this.sp_warning = this.NewStoryPage(GSCompany.COMPANY_INVALID, GSText(GSText.STR_SB_WARNING_TITLE));
+            GSStoryPage.NewElement(this.sp_warning, GSStoryPage.SPET_TEXT, 0, GSText(GSText.STR_SB_WARNING_2));
+            GSStoryPage.Show(this.sp_warning);
+            break;
+        // Issue a warning that the cargo list initialization has failed
+        case InitError.INDUSTRY_LIST:
+            this.sp_warning = this.NewStoryPage(GSCompany.COMPANY_INVALID, GSText(GSText.STR_SB_WARNING_TITLE));
+            GSStoryPage.NewElement(this.sp_warning, GSStoryPage.SPET_TEXT, 0, GSText(GSText.STR_SB_WARNING_3));
+            GSStoryPage.Show(this.sp_warning);
+            break;
+        case InitError.TOWN_GROWTH_RATE:
+            this.sp_warning = this.NewStoryPage(GSCompany.COMPANY_INVALID, GSText(GSText.STR_SB_WARNING_TITLE));
+            GSStoryPage.NewElement(this.sp_warning, GSStoryPage.SPET_TEXT, 0, GSText(GSText.STR_SB_WARNING_4));
+            GSStoryPage.Show(this.sp_warning);
+            break;
     }
 }
 


### PR DESCRIPTION
Also compare cargo list length with economy cargo list length to prevent choosing economy with matching beginning of the cargo list.

Added support of min pop demand options for industry randomization. Only the min pop demand values are changed, the categories are not sorted.

Better handling of warnings that cause the GS to stop. Handles also incorrect creation of cargo list and industry list.
