### PR TITLE
New: Custom story page

### DIFF
--- a/cargo.nut
+++ b/cargo.nut
@@ -826,7 +826,7 @@ function DefineCargosBySettings(economy)
                            [9,25,26,27,30],
                            [5,10,11,22,28,29]]
             ::CargoCatList <- [CatLabels.PUBLIC_SERVICES,CatLabels.RAW_MATERIALS,CatLabels.PROCESSED_MATERIALS,CatLabels.FINAL_PRODUCTS];
-            ::CargoMinPopDemand <- [500,1500,3000,6000];
+            ::CargoMinPopDemand <- [0,500,1500,4000];
             ::CargoPermille <- [60,35,25,15];
             ::CargoDecay <- [0.4,0.3,0.2,0.1];
             break;

--- a/company.nut
+++ b/company.nut
@@ -16,7 +16,6 @@ class Company
     statistics = null;      // contains texts for statistics in goal gui
     global_goal = null;     // global goal showing achieved points in the goal gui
     sp_welcome = null;      // story page welcome
-    sp_cargo = null;        // story page cargo
 
     constructor(id, load_data)
     {

--- a/lang/english.txt
+++ b/lang/english.txt
@@ -46,6 +46,13 @@ STR_SB_WELCOME_STATISTICS           :Company providing the majority of cargo to 
 STR_SB_WELCOME_ETERNAL_LOVE         :{SILVER}Eternal Love{BLACK} changes {ORANGE}local authority rating{BLACK} of each town once per month to at least {SILVER}{STRING}{BLACK}.
 STR_SB_WELCOME_END                  :Have fun!
 
+##### CUSTOM STORY BOOK #####
+STR_SB_CUSTOM_WELCOME       :Please find the server rules in the {ORANGE}{STRING} story book page{BLACK}.
+STR_SB_CUSTOM_TITLE         :Server rules
+# STR_SB_CUSTOM_1             :Rule 1
+# STR_SB_CUSTOM_2             :Rule 2
+STR_SB_CUSTOM_END           :
+
 ##### GOAL #####
 STR_STATISTICS_GROWTH_POINTS    :{STRING}{COMPANY}{BLACK} growth points{ORANGE}
 STR_STATISTICS_BIGGEST_TOWN     :{BLACK}Biggest town {SILVER}{TOWN}{ORANGE}

--- a/story.nut
+++ b/story.nut
@@ -5,6 +5,8 @@ class StoryEditor
     limit_min_transport = null;
     limiter_delay = null;
 
+    sp_cargo = null;
+    sp_custom = null;
     sp_warning = null;
 
     constructor() {
@@ -48,6 +50,11 @@ function StoryEditor::CheckParameters(companies)
 function StoryEditor::WelcomePage(sp_welcome)
 {    
     GSStoryPage.NewElement(sp_welcome, GSStoryPage.SPET_TEXT, 0, GSText(GSText.STR_SB_WELCOME_DESC));
+    
+    if (GSText.STR_SB_CUSTOM_END - GSText.STR_SB_CUSTOM_TITLE > 1) {
+        GSStoryPage.NewElement(sp_welcome, GSStoryPage.SPET_TEXT, 0, GSText(GSText.STR_SB_CUSTOM_WELCOME, GSText(GSText.STR_SB_CUSTOM_TITLE)));
+    }
+    
     GSStoryPage.NewElement(sp_welcome, GSStoryPage.SPET_TEXT, 0, GSText(GSText.STR_SB_WELCOME_CARGO, GSText(GSText.STR_ECONOMY_NONE + ::Economy), ::CargoCatNum, this.supply_impacting_part));
     GSStoryPage.NewElement(sp_welcome, GSStoryPage.SPET_TEXT, 0, GSText(GSText.STR_SB_WELCOME_STATISTICS));
 
@@ -153,6 +160,14 @@ function StoryEditor::CargoInfoPage(sp_cargo)
     }
 }
 
+/* Create a page showing custom information like server rules. */
+function StoryEditor::CustomPage(sp_custom)
+{
+    for (local i = GSText.STR_SB_CUSTOM_TITLE + 1; i < GSText.STR_SB_CUSTOM_END; i++) {
+        GSStoryPage.NewElement(sp_custom, GSStoryPage.SPET_TEXT, 0, GSText(i));
+    }
+}
+
 /* Create the StoryBook if it still doesn't exist. This function is
  * called only when (re)initializing all data, because the existing
  * storybook is stored by OTTD.
@@ -164,11 +179,17 @@ function StoryEditor::CreateStoryBook(companies, num_towns, init_error)
     foreach (page, _ in sb_list) GSStoryPage.Remove(page);
 
     if (!init_error) {
-        foreach (company in companies) {
-            // Create basic cargo informations page
-            company.sp_cargo = this.NewStoryPage(company.id, GSText(GSText.STR_SB_TITLE_1));
-            this.CargoInfoPage(company.sp_cargo);
+        // Create basic cargo informations page
+        this.sp_cargo = this.NewStoryPage(GSCompany.COMPANY_INVALID, GSText(GSText.STR_SB_TITLE_1));
+        this.CargoInfoPage(this.sp_cargo);
 
+        // Create custom page
+        if (GSText.STR_SB_CUSTOM_END - GSText.STR_SB_CUSTOM_TITLE > 1) {
+            this.sp_custom = this.NewStoryPage(GSCompany.COMPANY_INVALID, GSText(GSText.STR_SB_CUSTOM_TITLE));
+            this.CustomPage(this.sp_custom);
+        }
+
+        foreach (company in companies) {
             // Create welcome page
             company.sp_welcome = this.NewStoryPage(company.id, GSText(GSText.STR_SB_WELCOME_TITLE, SELF_MAJORVERSION, SELF_MINORVERSION));
             this.WelcomePage(company.sp_welcome);


### PR DESCRIPTION
New custom story page. Useful for example for server rules and other custom information. Change texts in the `lang/english.txt` to enable the custom story page. Add custom texts between `STR_SB_CUSTOM_TITLE` and `STR_SB_CUSTOM_END`, which will be added to the new page. If there is no text between them, the custom page is not created. `STR_SB_CUSTOM_WELCOME` is shown in the welcome page and points to the new custom page. `STR_SB_CUSTOM_TITLE` changes title of the custom page.

Example of a custom story page:
```
##### CUSTOM STORY BOOK #####
STR_SB_CUSTOM_WELCOME       :Please find the server rules in the {ORANGE}{STRING} story book page{BLACK}.
STR_SB_CUSTOM_TITLE         :Server rules
STR_SB_CUSTOM_1             :Rule 1
STR_SB_CUSTOM_2             :Rule 2
STR_SB_CUSTOM_END           
```
| Welcome story page      | Custom story page |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/22470227/158067022-bf9f9c93-2a51-4d09-ab9b-94093e39e51f.png) | ![image](https://user-images.githubusercontent.com/22470227/158067081-e3f19ef0-9a2f-4eda-88c5-45edb1d2af8e.png) |

