### PR TITLE
Fix: Cargo story page is global

### DIFF
--- a/story.nut
+++ b/story.nut
@@ -226,10 +226,6 @@ function StoryEditor::CreateStoryBook(companies, num_towns, init_error)
 
 function StoryEditor::CreateNewCompanyStoryBook(company)
 {
-    // Create basic cargo informations page
-    company.sp_cargo = this.NewStoryPage(company.id, GSText(GSText.STR_SB_TITLE_1));
-    this.CargoInfoPage(company.sp_cargo);
-
     // Create welcome page
     company.sp_welcome = this.NewStoryPage(company.id, GSText(GSText.STR_SB_WELCOME_TITLE, SELF_MAJORVERSION, SELF_MINORVERSION));
     this.WelcomePage(company.sp_welcome);


### PR DESCRIPTION
Fix that cargo story page is global, so does not need creating for each company.