### PR TITLE
Updated cargoes in XIS economy

### DIFF
--- a/cargo.nut
+++ b/cargo.nut
@@ -773,10 +773,10 @@ function DefineCargosBySettings(economy)
         case(Economies.XIS__THE_LOT): // XIS 0.6: The Lot
             ::CargoLimiter <- [0,2];
             ::CargoCat <- [[0,2],
-                       [6,23,24,25,29,33,38,43,48,54],
-                       [12,13,16,26,27,28,31,34,35,40,44,46,47,49,50,59,60],
-                       [1,4,8,9,10,14,15,19,21,30,32,37,41,45,51,52,53,55,61],
-                       [3,5,7,11,17,18,20,22,36,39,42,56,57,58]];
+                       [6,11,23,24,25,29,33,38,54],
+                       [4,12,13,16,26,27,28,31,34,35,40,43,44,46,47,48,49,50,52,59,60],
+                       [1,8,9,10,14,15,19,20,21,22,30,32,37,41,45,51,53,55,61],
+                       [3,5,7,17,18,36,39,42,56,57,58]];
             ::CargoCatList <- [CatLabels.PUBLIC_SERVICES,CatLabels.RAW_FOOD,CatLabels.RAW_MATERIALS,
                        CatLabels.PROCESSED_MATERIALS,CatLabels.FINAL_PRODUCTS];
             ::CargoMinPopDemand <- [0,500,1000,4000,8000];


### PR DESCRIPTION
Hello!
I went through XIS economy, and found some weird assignments of categories. There is my proposition of changes:
[4 - AORE/bauxite]: it's definitely raw material digged in bauxite mine, so it should be raw instead of processed one.
[11 - FOOD/food]: it's in final products, but due to gameplay it would be better to keep it in food category (can be delivered to hotels in cities, and there are not so many raw food category cargoes)
[20 - BOOM/explosives]: now it's final product, but it's used to create engineering supplies and created from other materials, so moving to processed material
[22 - FERT/fertiliser]: as above, but used for farm supplies
[43 - FICR/plant_fibres]: it's in raw food, but it's used only for creating technical things, so moving to raw materials
[48 - SALT/salt]: as above
[52 - SASH/soda_ash]: digged directly in soda ash mine, so should be raw material instead of processed one

Two things to discuss, not included in this PR but maybe worth considering:
* [19 - ENSP/engineering_supplies] and [21 - FMSP/farm_supplies]: now they are processed materials, used for production boost, shouldn't they be final products? In steeltown firs4 economy they are in this category also, but I'm wondering about moving it to final products.
* Looking at number of cargoes in category 1 - raw food, and 2 - raw material, it would be easier to satisfy raw materials (there are more cargoes in this category). How about swapping these two categories, making raw material "green" one, being the most needed category, and leaving food "red" one? This should make gameplay easier, and more balanced (the highest number of cargoes in the most needed category).