### PR TITLE
Add: Improved Town Industries v2

### DIFF
--- a/cargo.nut
+++ b/cargo.nut
@@ -52,6 +52,7 @@ enum Economies
     IOTC, // 0.1.4
     LUMBERJACK, // 0.1.0
     WRBI, // 1200
+    ITI2, // 2.0
     END,
 }
 
@@ -239,6 +240,9 @@ function GetEconomyCargoList(economy, cargo_list) {
         if (30 < cargo_list.len() && cargo_list[30] == "WSTE")
             list.append("WSTE");
         return list;
+    case(Economies.ITI2): // Improved Town Industries 2
+        return ["PASS","COAL","WSTE","OIL_","WDPR","GOOD","RFPR","WOOD","IORE","STEL","PAPR",
+                "PLAS","FOOD","BDMT","VALU","LVST","WDCH","SCMT","SCPR","GRAI"];
     default:
         return [];
     }
@@ -829,6 +833,19 @@ function DefineCargosBySettings(economy)
             ::CargoMinPopDemand <- [0,500,1500,4000];
             ::CargoPermille <- [60,35,25,15];
             ::CargoDecay <- [0.4,0.3,0.2,0.1];
+            break;
+        case(Economies.ITI2): // Improved Town Industries 2
+            ::CargoLimiter <- [0,2];
+            ::CargoCat <- [[0],
+                       [12],
+                       [13],
+                       [5],
+                       [14]];
+            ::CargoCatList <- [CatLabels.CATEGORY_I,CatLabels.CATEGORY_II,CatLabels.CATEGORY_III,
+                       CatLabels.CATEGORY_IV,CatLabels.CATEGORY_V];
+            ::CargoMinPopDemand <- [0,1000,2000,3000,4000];
+            ::CargoPermille <- [60,45,35,25,15];
+            ::CargoDecay <- [0.5,0.4,0.3,0.2,0.1];
             break;
         default:
             if (!CreateDefaultCargoCat())

--- a/lang/english.txt
+++ b/lang/english.txt
@@ -129,6 +129,7 @@ STR_ECONOMY_OTIS                :OTIS
 STR_ECONOMY_IOTC                :Industries of the Caribbean
 STR_ECONOMY_LUMBERJACK          :Lumberjack Industries
 STR_ECOMONY_WRBI                :Wannaroo Basic Industries
+STR_ECONOMY_ITI2                :Improved Town Industries
 
 ##### ETERNAL LOVE #####
 STR_ETERNAL_LOVE_OUTSTANDING    :outstanding


### PR DESCRIPTION
This adds compatibility for my latest industry set, a complete rework of Improved Town Industries with different cargos and mechanics.

I've added it as a new economy rather than overwriting ITI 1.x, in case people end up playing the old version.

It's ready for merge and release, as ITI 2.0 is finished and ready for release itself as soon as a new version of RVG is published.