### PR TITLE
Add: Probability to use nearby cargo types

### DIFF
--- a/industry.nut
+++ b/industry.nut
@@ -114,7 +114,7 @@ function InitIndustryLists()
     return true;
 }
 
-function RandomizeIndustry(ascending)
+function RandomizeIndustry(ascending, near_industries, near_industry_probability)
 {
     local categories = [];
 
@@ -124,93 +124,301 @@ function RandomizeIndustry(ascending)
     local list_3 = clone ::industries_3;
     local list_4 = clone ::industries_4;
 
+    local industry_cat_text = "";
+
     // 1. Category (PASS, MAIL)
 
-    // 2. Category
-    {
-        if (list_1.len() == 0) {
+    // 2. Category, pick 1 cargo
+    if ((near_industries[0].len() != 0 || near_industries[1].len() != 0) &&
+            GSBase.Chance(near_industry_probability, 100)) { // Use near industry
+
+        if (near_industries[1].len() == 0) { // Use raw industry for Cat II
+            local rand = GSBase.RandRange(near_industries[0].len());
+            categories.append([near_industries[0][rand]]);
+
+            // Find and remove industry id from the other array
+            foreach (idx, industry in list_raw) {
+                if (industry == near_industries[0][rand]) {
+                    list_raw.remove(idx);
+                    break;
+                }
+            }
+
+            industry_cat_text += " Cat II: [" + GSIndustryType.GetName(near_industries[0][rand]) + "(NEAR)]";
+            near_industries[0].remove(rand);
+        }
+        else { // Use 1 input industry for Cat II
+            local rand = GSBase.RandRange(near_industries[1].len());
+            categories.append([near_industries[1][rand]]);
+
+            // Find and remove industry id from the other array
+            foreach (idx, industry in list_1) {
+                if (industry == near_industries[1][rand]) {
+                    list_1.remove(idx);
+                    break;
+                }
+            }
+
+            industry_cat_text += " Cat II: [" + GSIndustryType.GetName(near_industries[1][rand]) + "(NEAR)]";
+            near_industries[1].remove(rand);
+        }
+    }
+    else { // Use random industry
+        if (list_1.len() == 0) { // Use raw industry for Cat II
             local rand = GSBase.RandRange(list_raw.len());
             categories.append([list_raw[rand]]);
+
+            // Find and remove industry id from the other array
+            foreach (idx, industry in near_industries[0]) {
+                if (industry == list_raw[rand]) {
+                    near_industries[0].remove(idx);
+                    break;
+                }
+            }
+
+            industry_cat_text += " Cat II: [" + GSIndustryType.GetName(list_raw[rand]) + "(RAND)]";
             list_raw.remove(rand);
         }
-        else {
+        else { // Use 1 input industry for Cat II
             local rand = GSBase.RandRange(list_1.len());
             categories.append([list_1[rand]]);
+
+            // Find and remove industry id from the other array
+            foreach (idx, industry in near_industries[1]) {
+                if (industry == list_1[rand]) {
+                    near_industries[1].remove(idx);
+                    break;
+                }
+            }
+
+            industry_cat_text += " Cat II: [" + GSIndustryType.GetName(list_1[rand]) + "(RAND)]";
             list_1.remove(rand);
         }
     }
 
-    // 3. Category
-    if (list_2.len() > 2 || (list_1.len() < 2 && list_2.len() > 0)) {
-        local rand = GSBase.RandRange(list_2.len());
-        categories.append([list_2[rand]]);
-        list_2.remove(rand);
+    // 3. Category, pick 2 cargos
+    if (near_industries[2].len() != 0 && GSBase.Chance(near_industry_probability, 100)) { // Use near industry
+        // Use 2 input industry for Cat III
+        local rand = GSBase.RandRange(near_industries[2].len());
+        categories.append([near_industries[2][rand]]);
+
+        // Find and remove industry id from the other array
+        foreach (idx, industry in list_2) {
+            if (industry == near_industries[2][rand]) {
+                list_2.remove(idx);
+                break;
+            }
+        }
+
+        industry_cat_text += " Cat III: [" + GSIndustryType.GetName(near_industries[2][rand]) + "(NEAR)]";
+        near_industries[2].remove(rand);
     }
-    else {
-        local rand = GSBase.RandRange(3);
-        if (rand < list_2.len()) {
+    else { // Use random industry
+        if (list_2.len() > 2 || (list_1.len() < 2 && list_2.len() > 0)) { // Use 2 input industry for Cat II
+            local rand = GSBase.RandRange(list_2.len());
             categories.append([list_2[rand]]);
+
+            // Find and remove industry id from the other array
+            foreach (idx, industry in near_industries[2]) {
+                if (industry == list_2[rand]) {
+                    near_industries[2].remove(idx);
+                    break;
+                }
+            }
+
+            industry_cat_text += " Cat III: [" + GSIndustryType.GetName(list_2[rand]) + "(RAND)]";
             list_2.remove(rand);
         }
         else {
-            if (list_raw.len() > 0) {
-                local rand_1 = GSBase.RandRange(list_1.len());
-                local rand_raw = GSBase.RandRange(list_raw.len());
-                categories.append([list_1[rand_1], list_raw[rand_raw]]);
-                list_1.remove(rand_1);
-                list_raw.remove(rand_raw);
+            // Prevent using only max 2 industries by giving chance to use 1+1
+            local rand = GSBase.RandRange(3);
+            if (rand < list_2.len()) {
+                categories.append([list_2[rand]]);
+
+                // Find and remove industry id from the other array
+                foreach (idx, industry in near_industries[2]) {
+                    if (industry == list_2[rand]) {
+                        near_industries[2].remove(idx);
+                        break;
+                    }
+                }
+
+                industry_cat_text += " Cat III: [" + GSIndustryType.GetName(list_2[rand]) + "(RAND)]";
+                list_2.remove(rand);
             }
             else {
-                local rand_1 = GSBase.RandRange(list_1.len());
-                local rand_2 = GSBase.RandRange(list_1.len() - 1);
-                categories.append([list_1[rand_1], list_1[rand_2 >= rand_1 ? rand_2 + 1 : rand_2]]);
-                list_1.remove(rand_1);
-                list_1.remove(rand_2);
+                if (list_raw.len() > 0) {
+                    local rand_1 = GSBase.RandRange(list_1.len());
+                    local rand_raw = GSBase.RandRange(list_raw.len());
+                    categories.append([list_1[rand_1], list_raw[rand_raw]]);
+
+                    // Find and remove industry id from the other array
+                    foreach (idx, industry in near_industries[1]) {
+                        if (industry == list_1[rand_1]) {
+                            near_industries[1].remove(idx);
+                            break;
+                        }
+                    }
+                    foreach (idx, industry in near_industries[0]) {
+                        if (industry == list_raw[rand_raw]) {
+                            near_industries[0].remove(idx);
+                            break;
+                        }
+                    }
+
+                    industry_cat_text += " Cat III: [" + GSIndustryType.GetName(list_1[rand_1]) + ", " + GSIndustryType.GetName(list_raw[rand_raw]) + "(RAND)]";
+                    list_1.remove(rand_1);
+                    list_raw.remove(rand_raw);
+                }
+                else {
+                    local rand_1 = GSBase.RandRange(list_1.len());
+                    local rand_1_ind = list_1[rand_1];
+                    list_1.remove(rand_1);
+                    local rand_2 = GSBase.RandRange(list_1.len() - 1);
+                    categories.append([rand_1_ind, list_1[rand_2]]);
+
+                    // Find and remove industry id from the other array
+                    foreach (idx, industry in near_industries[1]) {
+                        if (industry == list_1[rand_2] || industry == rand_1_ind) {
+                            near_industries[1].remove(idx);
+                        }
+                    }
+
+                    industry_cat_text += " Cat III: [" + GSIndustryType.GetName(rand_1_ind) + ", " + GSIndustryType.GetName(list_1[rand_2]) + "(RAND)]";
+                    list_1.remove(rand_2);
+                }
             }
         }
     }
 
-    // 4. Category
-    if (list_3.len() > 2 || ((list_2.len() == 0 || (list_1.len() + list_raw.len() == 0)) && list_3.len() > 0)) {
-        local rand = GSBase.RandRange(list_3.len());
-        categories.append([list_3[rand]]);
-        list_3.remove(rand);
+    // 4. Category, pick 3 cargos
+    if (near_industries[3].len() != 0 && GSBase.Chance(near_industry_probability, 100)) { // Use near industry
+        // Use 3 input industry for Cat IV
+        local rand = GSBase.RandRange(near_industries[3].len());
+        categories.append([near_industries[3][rand]]);
+
+        // Find and remove industry id from the other array
+        foreach (idx, industry in list_3) {
+            if (industry == near_industries[3][rand]) {
+                list_3.remove(idx);
+                break;
+            }
+        }
+
+        industry_cat_text += " Cat IV: [" + GSIndustryType.GetName(near_industries[3][rand]) + "(NEAR)]";
+        near_industries[3].remove(rand);
     }
-    else {
-        local rand = GSBase.RandRange(3);
-        if (rand < list_3.len()) {
+    else { // Use random industry
+        if (list_3.len() > 2 || ((list_2.len() == 0 || (list_1.len() + list_raw.len() == 0)) && list_3.len() > 0)) {
+            local rand = GSBase.RandRange(list_3.len());
             categories.append([list_3[rand]]);
+
+            // Find and remove industry id from the other array
+            foreach (idx, industry in near_industries[3]) {
+                if (industry == list_3[rand]) {
+                    near_industries[3].remove(idx);
+                    break;
+                }
+            }
+
+            industry_cat_text += " Cat IV: [" + GSIndustryType.GetName(list_3[rand]) + "(RAND)]";
             list_3.remove(rand);
         }
         else {
-            local list = clone list_1;
-            list.extend(list_raw);
+            // Prevent using only max 2 industries by giving chance to use 1+2
+            local rand = GSBase.RandRange(3);
+            if (rand < list_3.len()) {
+                categories.append([list_3[rand]]);
 
-            local rand_1 = GSBase.RandRange(list.len());
-            local rand_2 = GSBase.RandRange(list_2.len());
+                // Find and remove industry id from the other array
+                foreach (idx, industry in near_industries[3]) {
+                    if (industry == list_3[rand]) {
+                        near_industries[3].remove(idx);
+                        break;
+                    }
+                }
 
-            categories.append([list[rand_1], list_2[rand_2]]);
-            if (rand_1 < list_1.len())
-                list_1.remove(rand_1);
-            else
-                list_raw.remove(rand_1 - list_1.len());
-            list_2.remove(rand_2);
+                industry_cat_text += " Cat IV: [" + GSIndustryType.GetName(list_3[rand]) + "(RAND)]";
+                list_3.remove(rand);
+            }
+            else {
+                local list = clone list_1;
+                list.extend(list_raw);
+
+                local rand_1 = GSBase.RandRange(list.len());
+                local rand_2 = GSBase.RandRange(list_2.len());
+
+                categories.append([list[rand_1], list_2[rand_2]]);
+                industry_cat_text += " Cat III: [" + GSIndustryType.GetName(list[rand_1]) + ", " + GSIndustryType.GetName(list_2[rand_2]) + "(RAND)]";
+                if (rand_1 < list_1.len()) {
+                    // Find and remove industry id from the other array
+                    foreach (idx, industry in near_industries[1]) {
+                        if (industry == list[rand_1]) {
+                            near_industries[1].remove(idx);
+                            break;
+                        }
+                    }
+
+                    list_1.remove(rand_1);
+                }
+                else {
+                    // Find and remove industry id from the other array
+                    foreach (idx, industry in near_industries[0]) {
+                        if (industry == list[rand_1]) {
+                            near_industries[0].remove(idx);
+                            break;
+                        }
+                    }
+
+                    list_raw.remove(rand_1 - list_1.len());
+                }
+
+                // Find and remove industry id from the other array
+                foreach (idx, industry in near_industries[2]) {
+                    if (industry == list[rand_2]) {
+                        near_industries[2].remove(idx);
+                        break;
+                    }
+                }
+
+                list_2.remove(rand_2);
+            }
         }
     }
 
-    // 5. Category
-    if (list_4.len() > 2 || ((list_3.len() < 5 || (list_1.len() + list_raw.len() < 5)) && list_4.len() > 0)) {
-        local rand = GSBase.RandRange(list_4.len());
-        categories.append([list_4[rand]]);
-        list_4.remove(rand);
+    // 5. Category, pick 4 or more cargos
+    // Dont need to remove used ids in the last category
+    if (near_industries[4].len() != 0 && GSBase.Chance(near_industry_probability, 100)) { // Use near industry
+        // Use 4+ input industry for Cat V
+        local rand = GSBase.RandRange(near_industries[4].len());
+        categories.append([near_industries[4][rand]]);
+
+        industry_cat_text += " Cat V: [" + GSIndustryType.GetName(near_industries[4][rand]) + "(NEAR)]";
     }
-    else if (list_4.len() > 0) {
-        local rand = GSBase.RandRange(3);
-        if (rand < list_4.len()) {
+    else { // Use random industry
+        if (list_4.len() > 2 || ((list_3.len() < 5 || (list_1.len() + list_raw.len() < 5)) && list_4.len() > 0)) {
+            local rand = GSBase.RandRange(list_4.len());
             categories.append([list_4[rand]]);
-            list_4.remove(rand);
+            industry_cat_text += " Cat V: [" + GSIndustryType.GetName(list_4[rand]) + "(RAND)]";
         }
-        else {
+        else if (list_4.len() > 0 && (list_1.len() + list_raw.len() > 0) && list_3.len() > 0) {
+            local rand = GSBase.RandRange(3);
+            if (rand < list_4.len()) {
+                categories.append([list_4[rand]]);
+                industry_cat_text += " Cat V: [" + GSIndustryType.GetName(list_4[rand]) + "(RAND)]";
+            }
+            else {
+                local list = clone list_1;
+                list.extend(list_raw);
+
+                local rand_1 = GSBase.RandRange(list.len());
+                local rand_3 = GSBase.RandRange(list_3.len());
+
+                categories.append([list[rand_1], list_3[rand_3]]);
+                industry_cat_text += " Cat V: [" + GSIndustryType.GetName(list[rand_1]) + ", " + GSIndustryType.GetName(list_3[rand_3]) + "(RAND)]";
+            }
+        }
+        else if (list_3.len() > 4 && (list_1.len() + list_raw.len() > 4)) {
             local list = clone list_1;
             list.extend(list_raw);
 
@@ -218,27 +426,11 @@ function RandomizeIndustry(ascending)
             local rand_3 = GSBase.RandRange(list_3.len());
 
             categories.append([list[rand_1], list_3[rand_3]]);
-            if (rand_1 < list_1.len())
-                list_1.remove(rand_1);
-            else
-                list_raw.remove(rand_1 - list_1.len());
-            list_3.remove(rand_3);
+            industry_cat_text += " Cat V: [" + GSIndustryType.GetName(list[rand_1]) + ", " + GSIndustryType.GetName(list_3[rand_3]) + "(RAND)]";
         }
     }
-    else if (list_3.len() > 4 && (list_1.len() + list_raw.len() > 4)) {
-        local list = clone list_1;
-        list.extend(list_raw);
 
-        local rand_1 = GSBase.RandRange(list.len());
-        local rand_3 = GSBase.RandRange(list_3.len());
-
-        categories.append([list[rand_1], list_3[rand_3]]);
-        if (rand_1 < list_1.len())
-            list_1.remove(rand_1);
-        else
-            list_raw.remove(rand_1 - list_1.len());
-        list_3.remove(rand_3);
-    }
+    Log.Info(GSTown.GetName(this.id) + ":" + industry_cat_text, Log.LVL_SUB_DECISIONS);
 
     if (!ascending) {
         local category_reverse = [];
@@ -259,6 +451,10 @@ function GetCargoCatFromIndustryCat(industry_cat)
         foreach (ind_idx, ind in cat) {
             local cargo_list = GSIndustryType.GetAcceptedCargo(ind);
             foreach (cargo, _ in cargo_list) {
+                // Ignore PASS and MAIL
+                if (cargo == 0 || cargo == 2)
+                    continue;
+
                 local found = false;
                 foreach (c in cargo_cat.top()) {
                     if (cargo == c) {
@@ -457,4 +653,105 @@ function GetRawIndustryToProspect(ignore_list)
     industry_type_list.Sort(GSList.SORT_BY_VALUE, GSList.SORT_ASCENDING);
 
     return industry_type_list.Begin();
+}
+
+/**
+ * @brief Find closest town to each industry on the map.
+ * @return table containing {town_id, [industry_ids]}
+ */
+function GetNearbyIndustriesToTowns()
+{
+    local industry_list = GSIndustryList();
+    local town_list = GSTownList();
+
+    // Initialize town industries table
+    local town_industries = {};
+    foreach (town_id, _ in town_list) {
+        town_industries[town_id] <- [];
+    }
+
+    // Find closest town to each industry
+    foreach (industry_id, _ in industry_list) {
+        local town_list_clone = GSList();
+        town_list_clone.AddList(town_list);
+        local industry_location = GSIndustry.GetLocation(industry_id);
+
+        town_list_clone.Valuate(GSTown.GetDistanceManhattanToTile, industry_location);
+        town_list_clone.Sort(GSList.SORT_BY_VALUE, true);
+
+        town_industries[town_list_clone.Begin()].append(industry_id);
+    }
+
+    // Print town_industries
+    DebugTownIndustries(town_industries);
+
+    return town_industries;
+}
+
+function GetTownsNearbyIndustryPerCategory()
+{
+    local town_industries = GetNearbyIndustriesToTowns();
+    local town_industry_category = {};
+
+    foreach (town_id, industry_ids in town_industries) {
+        town_industry_category[town_id] <- [];
+
+        for (local i = 0; i < 5; ++i) {
+            town_industry_category[town_id].append([]);
+        }
+
+        foreach (industry_id in industry_ids) {
+            local industry_type_id = GSIndustry.GetIndustryType(industry_id);
+
+            // Determine the category of this industry type
+            local cargo_list = GSIndustryType.GetAcceptedCargo(industry_type_id);
+            cargo_list.RemoveItem(0); // exclude PASS
+            cargo_list.RemoveItem(2); // exclude MAIL
+            local category = -1;
+            switch (cargo_list.Count())
+            {
+                case 0:
+                    break;
+                case 1:
+                    if (GSIndustryType.IsRawIndustry(industry_type_id))
+                        category = 0;
+                    else
+                        category = 1;
+                    break;
+                case 2:
+                    if (GSIndustryType.IsRawIndustry(industry_type_id))
+                        category = 0;
+                    else
+                        category = 2;
+                    break;
+                case 3:
+                    category = 3;
+                    break;
+                default:
+                    category = 4;
+            }
+
+            // No accepting cargo
+            if (category < 0)
+                continue;
+
+            // Check if it already exists in the list, if not, add it there
+            local found = false;
+            foreach (saved_industry_type in town_industry_category[town_id][category]) {
+                if (saved_industry_type == industry_type_id) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found) {
+                town_industry_category[town_id][category].append(industry_type_id);
+            }
+        }
+    }
+
+    // Print results
+    DebugNearTownIndustryTypes(town_industry_category);
+
+    return town_industry_category;
 }

--- a/info.nut
+++ b/info.nut
@@ -91,6 +91,14 @@ class MainClass extends GSInfo
                     _14 = "Descending",
                     _15 = "Ascending" });
 
+        AddSetting({ name = "near_cargo_probability",
+                    description = "Randomization: Probability to use nearby cargo types [%]",
+                    easy_value = 100,
+                    medium_value = 50,
+                    hard_value = 0,
+                    custom_value = 50,
+                    flags = CONFIG_INGAME, min_value = 0, max_value = 100, step_size = 10});
+
         AddSetting({ name = "display_cargo",
                 description = "Randomization: Show town cargos from start",
                 easy_value = 1,
@@ -149,7 +157,7 @@ class MainClass extends GSInfo
             hard_value = -1,
             custom_value = -1,
             flags = CONFIG_INGAME, min_value = -1, max_value = 50000, step_size = 100});
-        
+
         AddSetting({
             name = "category_2_min_pop",
             description = "Category 2: Minimum population demand (-1 = default)",
@@ -158,7 +166,7 @@ class MainClass extends GSInfo
             hard_value = -1,
             custom_value = -1,
             flags = CONFIG_INGAME, min_value = -1, max_value = 50000, step_size = 100});
-        
+
         AddSetting({
             name = "category_3_min_pop",
             description = "Category 3: Minimum population demand (-1 = default)",
@@ -167,7 +175,7 @@ class MainClass extends GSInfo
             hard_value = -1,
             custom_value = -1,
             flags = CONFIG_INGAME, min_value = -1, max_value = 50000, step_size = 100});
-        
+
         AddSetting({
             name = "category_4_min_pop",
             description = "Category 4: Minimum population demand (-1 = default)",

--- a/main.nut
+++ b/main.nut
@@ -328,7 +328,7 @@ function MainClass::UpdateCompanyList()
         // Initialize new company
         local company = Company(c, false);
         this.companies.append(company);
-        
+
         if (this.story_editor != null)
             this.story_editor.CreateNewCompanyStoryBook(company);
     }
@@ -369,12 +369,21 @@ function MainClass::CreateTownList()
     else if (pause_level < 1)
         GSGameSettings.SetValue("construction.command_pause_level", 1);
 
+    // Create list of cargos/industries near each town
+    local near_town;
+    if (::SettingsTable.randomization == Randomization.INDUSTRY_DESC ||
+        ::SettingsTable.randomization == Randomization.INDUSTRY_ASC)
+        near_town = GetTownsNearbyIndustryPerCategory();
+    else
+        near_town = GetTownsNearbyCargoPerCategory();
+
     local towns_list = GSTownList();
     local towns_array = [];
 
     local min_transport = GSController.GetSetting("limit_min_transport");
+    local near_cargo_probability = GSController.GetSetting("near_cargo_probability");
     foreach (t, _ in towns_list) {
-        towns_array.append(GoalTown(t, this.load_saved_data, min_transport));
+        towns_array.append(GoalTown(t, this.load_saved_data, min_transport, near_town[t], near_cargo_probability));
     }
 
     // Reset to previous settings
@@ -392,8 +401,17 @@ function MainClass::CreateTownList()
  */
 function MainClass::UpdateTownList(town_id)
 {
+    // Create list of cargos/industries near each town
+    local near_town;
+    if (::SettingsTable.randomization == Randomization.INDUSTRY_DESC ||
+        ::SettingsTable.randomization == Randomization.INDUSTRY_ASC)
+        near_town = GetTownsNearbyIndustryPerCategory();
+    else
+        near_town = GetTownsNearbyCargoPerCategory();
+
     local min_transport = GSController.GetSetting("limit_min_transport");
-    this.towns.append(GoalTown(town_id, false, min_transport));
+    local near_cargo_probability = GSController.GetSetting("near_cargo_probability");
+    this.towns.append(GoalTown(town_id, false, min_transport, near_town[town_id], near_cargo_probability));
     Log.Info("New town founded: "+GSTown.GetName(town_id)+" (id: "+town_id+")", Log.LVL_DEBUG);
 }
 

--- a/strings.nut
+++ b/strings.nut
@@ -9,7 +9,7 @@ function GoalTown::TownBoxText(growth_enabled, text_mode, redraw=false)
         if (display_cargo) {
             text_townbox = GSText(GSText["STR_TOWNBOX_CARGO_"+(::CargoCatNum-1)]);
             text_townbox = this.TownTextContributor(text_townbox);
-            
+
             local cargo_mask = 0;
             foreach (cargo in ::CargoLimiter) {
                 cargo_mask = cargo_mask | 1 << cargo;
@@ -312,4 +312,45 @@ function GoalTown::DebugRandomizationIndustry(categories)
         }
     }
     Log.Info(GSTown.GetName(this.id) + ": " + str, Log.LVL_SUB_DECISIONS);
+}
+
+function DebugTownIndustries(town_industries)
+{
+    foreach (town, industry_list in town_industries) {
+        local industries_text = "";
+        foreach (industry in industry_list) {
+            industries_text += "    " + GSIndustry.GetName(industry) + ", ";
+        }
+        Log.Info(GSTown.GetName(town) + ": " + industries_text, Log.LVL_DEBUG);
+    }
+}
+
+function DebugNearTownCargos(near_town_cargos)
+{
+    foreach (town, categories in near_town_cargos) {
+        local cargos_text = "";
+        foreach (cat_idx, cargos in categories) {
+            cargos_text += cat_idx + " [";
+            foreach (cargo in cargos) {
+                cargos_text += GSCargo.GetCargoLabel(cargo) + ", ";
+            }
+            cargos_text += "] ";
+        }
+        Log.Info(GSTown.GetName(town) + ": " + cargos_text, Log.LVL_DEBUG);
+    }
+}
+
+function DebugNearTownIndustryTypes(near_town_industry_types)
+{
+    foreach (town, categories in near_town_industry_types) {
+        local industry_text = "";
+        foreach (cat_idx, industry_types in categories) {
+            industry_text += cat_idx + " [";
+            foreach (industry in industry_types) {
+                industry_text += GSIndustryType.GetName(industry) + ", ";
+            }
+            industry_text += "] ";
+        }
+        Log.Info(GSTown.GetName(town) + ": " + industry_text, Log.LVL_DEBUG);
+    }
 }

--- a/town.nut
+++ b/town.nut
@@ -25,7 +25,7 @@ class GoalTown
     town_text_scroll = null;    // scroll town text when more than 3 categories are to be displayed
     initialized = null;         // Town is fully initialized
 
-    constructor(town_id, load_town_data, min_transported) {
+    constructor(town_id, load_town_data, min_transported, near_town, near_town_probability) {
         this.id = town_id;
         this.tgr_array_len = 8;
         this.tgr_average = null;
@@ -47,7 +47,7 @@ class GoalTown
             this.tgr_array = array(tgr_array_len, 0);
             this.limit_transported = 0;
             this.limit_delay = 0;
-            this.Randomization();
+            this.Randomization(near_town, near_town_probability);
             this.DisableOrigCargoGoal();
 
             // These commands require at least all non-construcion actions during pause allowed
@@ -250,7 +250,7 @@ function GoalTown::MonthlyManageTown()
     }
 
     // Calculates new town growth rate based on missing cargo percentage
-    // Firstly a maximum growth rate for the town is calculated with g_factor 
+    // Firstly a maximum growth rate for the town is calculated with g_factor
     // being the growth rate at 0 population and exponentially increasing.
     // An exponential extra growth is calculated based on missing cargo requirements.
     // The max growth rate and difference between max growth rate and lowest growth rate
@@ -495,53 +495,52 @@ function GoalTown::UpdateTownText(info_mode)
     }
 }
 
-function GoalTown::Randomization()
+function GoalTown::Randomization(near_town, near_town_probability)
 {
     switch (::SettingsTable.randomization) {
         case Randomization.INDUSTRY_ASC:
         case Randomization.INDUSTRY_DESC:
         {
-            local industry_cat = RandomizeIndustry(::SettingsTable.randomization == Randomization.INDUSTRY_ASC);
+            local industry_cat = RandomizeIndustry(::SettingsTable.randomization == Randomization.INDUSTRY_ASC, near_town, near_town_probability);
             this.town_cargo_cat = GetCargoCatFromIndustryCat(industry_cat);
             this.cargo_hash = GetIndustryHash(industry_cat);
-            this.DebugRandomizationIndustry(industry_cat);
             break;
         }
         case Randomization.FIXED_1:
-            this.town_cargo_cat = RandomizeFixed(1);
+            this.town_cargo_cat = RandomizeFixed(1, near_town, near_town_probability);
             break;
         case Randomization.FIXED_2:
-            this.town_cargo_cat = RandomizeFixed(2);
+            this.town_cargo_cat = RandomizeFixed(2, near_town, near_town_probability);
             break;
         case Randomization.FIXED_3:
-            this.town_cargo_cat = RandomizeFixed(3);
+            this.town_cargo_cat = RandomizeFixed(3, near_town, near_town_probability);
             break;
         case Randomization.FIXED_5:
-            this.town_cargo_cat = RandomizeFixed(5);
+            this.town_cargo_cat = RandomizeFixed(5, near_town, near_town_probability);
             break;
         case Randomization.FIXED_7:
-            this.town_cargo_cat = RandomizeFixed(7);
+            this.town_cargo_cat = RandomizeFixed(7, near_town, near_town_probability);
             break;
         case Randomization.RANGE_1_2:
-            this.town_cargo_cat = RandomizeRange(1, 2);
+            this.town_cargo_cat = RandomizeRange(1, 2, near_town, near_town_probability);
             break;
         case Randomization.RANGE_1_3:
-            this.town_cargo_cat = RandomizeRange(1, 3);
+            this.town_cargo_cat = RandomizeRange(1, 3, near_town, near_town_probability);
             break;
         case Randomization.RANGE_2_3:
-            this.town_cargo_cat = RandomizeRange(2, 3);
+            this.town_cargo_cat = RandomizeRange(2, 3, near_town, near_town_probability);
             break;
         case Randomization.RANGE_3_5:
-            this.town_cargo_cat = RandomizeRange(3, 5);
+            this.town_cargo_cat = RandomizeRange(3, 5, near_town, near_town_probability);
             break;
         case Randomization.RANGE_3_7:
-            this.town_cargo_cat = RandomizeRange(3, 7);
+            this.town_cargo_cat = RandomizeRange(3, 7, near_town, near_town_probability);
             break;
         case Randomization.DESCENDING:
-            this.town_cargo_cat = RandomizePyramid(false);
+            this.town_cargo_cat = RandomizePyramid(false, near_town, near_town_probability);
             break;
         case Randomization.ASCENDING:
-            this.town_cargo_cat = RandomizePyramid(true);
+            this.town_cargo_cat = RandomizePyramid(true, near_town, near_town_probability);
             break;
         default:
             this.town_cargo_cat = ::CargoCat;
@@ -551,6 +550,4 @@ function GoalTown::Randomization()
         ::SettingsTable.randomization != Randomization.INDUSTRY_DESC) {
         this.cargo_hash = GetCargoHash(this.town_cargo_cat);
     }
-
-    this.DebugCargoTable(this.town_cargo_cat);
 }


### PR DESCRIPTION
This feature is used to specify the probability of choosing a nearby cargo type / industry type instead of a random one. Added new parameter `Randomization: Probability to use nearby cargo types [%]`, which specifies the % chance of chosing nearby compared to random cargo type.

Cargo randomization:
For each town, a list of nearest industries is created. From these industries, a cargo list is created for each cargo category based on used economy. These cargo lists specify which cargo types are near that town and to which category they belong. When randomizing cargo categories, based on the probability parameter, cargo from near cargo types is chosen compared to random cargo type. If there are no near cargo types for that category, random cargo type is chosen.

Industry randomization:
For each town, a list of nearest industries is created. These industries are then converted to industry types and split into their specific categories, removing duplicates. When chosing random industry type, when a near industry type exists for that category, based on the probability parameter, the near industry is chosen.