### PR TITLE
Fix STR_SB_WELCOME_LIMIT_GROWTH_DELAY substitution

### DIFF
--- a/lang/english.txt
+++ b/lang/english.txt
@@ -40,7 +40,7 @@ STR_SB_WARNING_4         :You must set parameter {ORANGE}Environment->Towns->Tow
 STR_SB_WELCOME_TITLE     :Renewed Village Growth {NUM}.{NUM}
 STR_SB_WELCOME_DESC      :{SILVER}Renewed Village Growth (RVG){BLACK} is a game script which {ORANGE}changes the way towns grow{BLACK} in OpenTTD. Various cargo requirements are defined for each town that need to be - partially or completely - monthly satisfied to make the towns grow faster. More information can be found in the {ORANGE}Readme file{BLACK}.
 STR_SB_WELCOME_CARGO     :Economy {SILVER}{STRING}{BLACK} consists of {SILVER}{NUM} categories{BLACK}. To fulfill a category, deliver one or more of the category specific cargos to a {ORANGE}station near the town which accepts that cargo type{BLACK}. Fulfill the requirements above {SILVER}{NUM}%{BLACK} to {ORANGE}make the towns grow faster{BLACK}. More information about cargo categories are shown in the {ORANGE}Cargo categories story book page{BLACK}.
-STR_SB_WELCOME_LIMIT_GROWTH         :{SILVER}{CARGO_LIST}{BLACK} from that town can {ORANGE}stop the town growth{BLACK}. Transport at least {SILVER}{NUM}%{BLACK} of those cargo types to {ORANGE}allow town growth{BLACK}. {STRING}
+STR_SB_WELCOME_LIMIT_GROWTH         :{SILVER}{CARGO_LIST}{BLACK} from that town can {ORANGE}stop the town growth{BLACK}. Transport at least {SILVER}{NUM}%{BLACK} of those cargo types to {ORANGE}allow town growth{BLACK}. {STRING1}
 STR_SB_WELCOME_LIMIT_GROWTH_DELAY   :The growth stops after {SILVER}{NUM} months{BLACK} of not fulfilling this requirement.
 STR_SB_WELCOME_STATISTICS           :Company providing the majority of cargo to a town becomes its {ORANGE}Contributor{BLACK}. Every new population above largest population of that town is counted towards {ORANGE}growth points{BLACK} of that company. See the growth points and statistics in the {ORANGE}Goal list{BLACK}.
 STR_SB_WELCOME_ETERNAL_LOVE         :{SILVER}Eternal Love{BLACK} changes {ORANGE}local authority rating{BLACK} of each town once per month to at least {SILVER}{STRING}{BLACK}.
@@ -160,3 +160,4 @@ STR_WHITE                       :{WHITE}
 STR_SILVER                      :{SILVER}
 
 STR_EMPTY                       :
+STR_STRING                      :{STRING}

--- a/story.nut
+++ b/story.nut
@@ -64,12 +64,8 @@ function StoryEditor::WelcomePage(sp_welcome)
             limiter_cargos = limiter_cargos | 1 << cargo;
         }
 
-        if (this.limiter_delay > 0) {
-            GSStoryPage.NewElement(sp_welcome, GSStoryPage.SPET_TEXT, 0, GSText(GSText.STR_SB_WELCOME_LIMIT_GROWTH, limiter_cargos, this.limit_min_transport, GSText(GSText.STR_SB_WELCOME_LIMIT_GROWTH_DELAY, this.limiter_delay)));
-        }
-        else {
-            GSStoryPage.NewElement(sp_welcome, GSStoryPage.SPET_TEXT, 0, GSText(GSText.STR_SB_WELCOME_LIMIT_GROWTH, limiter_cargos, this.limit_min_transport, GSText.STR_EMPTY));
-        }
+        local limiter_delay_text = this.limiter_delay > 0 ? GSText(GSText.STR_SB_WELCOME_LIMIT_GROWTH_DELAY, this.limiter_delay) : GSText(GSText.STR_STRING, GSText(GSText.STR_EMPTY));
+        GSStoryPage.NewElement(sp_welcome, GSStoryPage.SPET_TEXT, 0, GSText(GSText.STR_SB_WELCOME_LIMIT_GROWTH, limiter_cargos, this.limit_min_transport, limiter_delay_text));
     }
 
     if (this.eternal_love > 0) {


### PR DESCRIPTION
STR_SB_WELCOME_LIMIT_GROWTH must use {STRING1} instead of {STRING} because STR_SB_WELCOME_LIMIT_GROWTH_DELAY consumes one parameter.

For the case when the extra string is omitted, I introduced a trivial STR_STRING string for the sake of consuming one extra parameter.

Tested on both OpenTTD 13.0 and nightly, with and without limiter_delay.

Fix #114.