### PR TITLE
Fix: FIRS 3 Arctic Basic cargos should not be in multiple categories

### DIFF
--- a/cargo.nut
+++ b/cargo.nut
@@ -637,8 +637,8 @@ function DefineCargosBySettings(economy)
             ::CargoCat <- [[0,2],
                        [8,11,14],
                        [1,7,10,17,18],
-                       [3,4,9,13,15,16],
-                       [6,8,12,16]];
+                       [3,4,9,13,15],
+                       [6,12,16]];
             ::CargoCatList <- [CatLabels.PUBLIC_SERVICES,CatLabels.RAW_FOOD,CatLabels.RAW_MATERIALS,
                        CatLabels.PROCESSED_MATERIALS,CatLabels.FINAL_PRODUCTS];
             ::CargoMinPopDemand <- [0,500,1000,4000,8000];


### PR DESCRIPTION
## Motivation / Problem

I am playing on the Discord server's JGR Server 2, which uses FIRS 3 Arctic Basic and RVG v92. We are experiencing a bug where some cargos are not counting towards delivery requirements.

I believe this is because the problem cargos are in multiple categories, but only count toward the lower tier.

## Description

This PR ensures that each cargo in FIRS 3 Arctic Basic only appears in one category. 
* Alcohol (cargo ID 8) appears only in Raw Food. Since it's generated by one of the port industries, it's too easily available to count toward Final Products, in my opinion.
* Fertilizer (16) appears only in Final Products.

## Limitations

I have not checked any other economies for cargos in multiple categories.