### PR TITLE
Fix: Misspelling of "Passenger" in subsidy type setting

### DIFF
--- a/info.nut
+++ b/info.nut
@@ -160,7 +160,7 @@ class MainClass extends GSInfo
         AddLabels("subsidies_type", {
                 _0 = "None",
                 _1 = "All",
-                _2 = "Passanger",
+                _2 = "Passenger",
                 _3 = "Cargo"});
 
         AddSetting({

--- a/subsidies.nut
+++ b/subsidies.nut
@@ -2,7 +2,7 @@ enum SubsidiesType
 {
     NONE = 0,
     ALL = 1,
-    PASSANGER = 2,
+    PASSENGER = 2,
     CARGO = 3
 }
 
@@ -156,7 +156,7 @@ function CreateSubsidies(towns, companies)
         };
 
         // Create town subsidy
-        if (subsidies_type == SubsidiesType.ALL || subsidies_type == SubsidiesType.PASSANGER) {
+        if (subsidies_type == SubsidiesType.ALL || subsidies_type == SubsidiesType.PASSENGER) {
             local biggest_town_id = GetBiggestPopulationTown(town_list, towns);
             if (biggest_town_id != null) {
                 local closest_town_id = FindClosestTown(sorted_towns.not_monitored, biggest_town_id);


### PR DESCRIPTION
In the GS configuration window, the dropdown window to select subsidy types misspells "Passenger" as "Passanger".

This PR fixes this string typo, as well as the enum.