### PR TITLE
Codechange: Improve performance of GetNearbyIndustriesToTowns

### DIFF
--- a/industry.nut
+++ b/industry.nut
@@ -675,14 +675,8 @@ function GetNearbyIndustriesToTowns()
 
     // Find closest town to each industry
     foreach (industry_id, _ in industry_list) {
-        local town_list_clone = GSList();
-        town_list_clone.AddList(town_list);
         local industry_location = GSIndustry.GetLocation(industry_id);
-
-        town_list_clone.Valuate(GSTown.GetDistanceManhattanToTile, industry_location);
-        town_list_clone.Sort(GSList.SORT_BY_VALUE, true);
-
-        town_industries[town_list_clone.Begin()].append(industry_id);
+        town_industries[GSTile.GetClosestTown(industry_location)].append(industry_id);
     }
 
     // Print town_industries


### PR DESCRIPTION
The existing implementation has worse than O(N) behaviour and churns a lot of memory while doing it, which makes for a long delay on large maps.
`GSTile.GetClosestTown` already solves this problem in an efficient way.