### PR TITLE
Change: Optimized save/load functions

### DIFF
--- a/info.nut
+++ b/info.nut
@@ -20,7 +20,7 @@ class MainClass extends GSInfo
     function GetURL()                   { return "https://www.tt-forums.net/viewtopic.php?f=65&t=87052"; }
     function GetVersion()               { return SELF_VERSION; }
     function GetDate()                  { return SELF_DATE; }
-    function GetAPIVersion()            { return "1.10"; }
+    function GetAPIVersion()            { return "12"; }
     function MinVersionToLoad()         { return SELF_MINLOADVERSION; }
     function CreateInstance()           { return "MainClass"; }
     function GetSettings() {

--- a/main.nut
+++ b/main.nut
@@ -196,6 +196,7 @@ function MainClass::Init()
     this.towns = this.CreateTownList();
     if (this.towns.len() > SELF_MAX_TOWNS)
         return InitError.TOWN_NUMBER;
+    Log.Info("Setup " + this.towns.len() + " towns", Log.LVL_INFO);
 
     // Run industry stabilizer
     Log.Info("Prospecting raw industries ... (can take a while on large maps)", Log.LVL_INFO);

--- a/town.nut
+++ b/town.nut
@@ -69,9 +69,9 @@ class GoalTown
             this.town_supplied_cat = ::TownDataTable[this.id].town_supplied_cat;
             this.town_stockpiled_cat = ::TownDataTable[this.id].town_stockpiled_cat;
             this.tgr_array = ::TownDataTable[this.id].tgr_array;
-            this.limit_transported = (::TownDataTable[this.id].limit_transported_upper + 0x7FFFFFFF << 32) | (::TownDataTable[this.id].limit_transported_lower + 0X7FFFFFFF);
+            this.limit_transported = ::TownDataTable[this.id].limit_transported;
             this.limit_delay = ::TownDataTable[this.id].limit_delay;
-            this.cargo_hash = (::TownDataTable[this.id].cargo_hash_upper + 0x7FFFFFFF << 32) | (::TownDataTable[this.id].cargo_hash_lower + 0X7FFFFFFF);
+            this.cargo_hash = ::TownDataTable[this.id].cargo_hash;
             if (::SettingsTable.randomization == Randomization.INDUSTRY_DESC
              || ::SettingsTable.randomization == Randomization.INDUSTRY_ASC)
                 this.town_cargo_cat = GetCargoCatFromIndustryCat(GetIndustryTable(this.cargo_hash));
@@ -127,11 +127,9 @@ function GoalTown::SavingTownData()
     town_data.town_supplied_cat <- this.town_supplied_cat;
     town_data.town_stockpiled_cat <- this.town_stockpiled_cat;
     town_data.tgr_array <- this.tgr_array;
-    town_data.limit_transported_upper <- ((this.limit_transported >> 32) - 0X7FFFFFFF);
-    town_data.limit_transported_lower <- ((this.limit_transported & 0xFFFFFFFF) - 0X7FFFFFFF);
+    town_data.limit_transported <- this.limit_transported;
     town_data.limit_delay <- this.limit_delay;
-    town_data.cargo_hash_upper <- ((this.cargo_hash >> 32) - 0X7FFFFFFF);
-    town_data.cargo_hash_lower <- ((this.cargo_hash & 0xFFFFFFFF) - 0X7FFFFFFF);
+    town_data.cargo_hash <- this.cargo_hash;
     return town_data;
 }
 

--- a/version.nut
+++ b/version.nut
@@ -3,4 +3,4 @@ SELF_MINLOADVERSION <- 90       // minimum integer version of GS that can load t
 SELF_MAJORVERSION <- 9          // main version of the GS, releases with same major version should be saveload compatible
 SELF_MINORVERSION <- 3          // minor version of the GS, incremental subreleases of the major version, saveload compatible
 SELF_DATE <- "2023-12-03"       // release date
-SELF_MAX_TOWNS <- 1400          // maximum number of towns that can be successfully saved in this release
+SELF_MAX_TOWNS <- 2000          // maximum number of towns that can be successfully saved in this release


### PR DESCRIPTION
With the fix of saving int64 in https://github.com/OpenTTD/OpenTTD/pull/9415, the saving and loading town functions could be optimized to not split `limit_transported` and `cargo_hash` into two int32 variables. With this change, the per town saving opcodes were reduced from 65 to 49, which allows to save 2000 towns. API version was increased to 12, where this int64 saving was fixed.