### PR TITLE
Fix: Adding towns in scenario editor

### DIFF
--- a/town.nut
+++ b/town.nut
@@ -34,7 +34,7 @@ class GoalTown
         /* If there isn't saved data for the towns, we
          * initialize them. Otherwise, we load saved data.
          */
-        if (!load_town_data) {
+        if (!load_town_data || this.id >= ::TownDataTable.len()) {
             this.sign_id = -1;
             this.contributor = -1;
             this.max_population = GSTown.GetPopulation(this.id);


### PR DESCRIPTION
When a scenario is started, the GS is initialized with the current towns. If the savegame is converted back to a scenario and new towns are added, the GS tries to load them, but they are not in the save data, which breaks the GS. Solved by checking if the town index exists in the save data, and if not, initialize the town.