### PR TITLE
Fix: Use updated GSToyLib v2

### DIFF
--- a/main.nut
+++ b/main.nut
@@ -13,7 +13,7 @@ Log <- SuperLib.Log;
 Helper <- SuperLib.Helper;
 
 // Import ToyLib
-import("Library.GSToyLib", "GSToyLib", 1);
+import("Library.GSToyLib", "GSToyLib", 2);
 import("Library.SCPLib", "SCPLib", 45);
 
 enum Randomization {


### PR DESCRIPTION
GSToyLib stopped working since OpenTTD 12 due to API changes. This uses fixed version [GSToyLib v2](https://bananas.openttd.org/package/game-script-library/544c4753).