### PR TITLE
Add support for Default Industries Plus

### DIFF
--- a/cargo.nut
+++ b/cargo.nut
@@ -67,6 +67,7 @@ enum Economies
     REAL, // Real Industries Beta
     MINIMALIST, // 1.1
     PIRS, // PIRS 2022
+    DEFAULTINDPLUS__TEMPERATE, // DefaultIndustriesPlus Temperate
     END,
 }
 
@@ -310,6 +311,11 @@ function GetEconomyCargoList(economy, cargo_list) {
     case(Economies.PIRS): // PIRS 2022
         return ["PASS","COAL","MAIL","OIL_","FISH","GOOD","GRAI","WOOD","IORE","STEL","WDPR",
                 "FOOD","FRUT","ENSP","FMSP","RFPR","PETR"];
+
+    case(Economies.DEFAULTINDPLUS__TEMPERATE): // DefaultIndustriesPlus Temperate
+        return ["PASS", "COAL", "MAIL", "OIL_", "LVST", "GOOD", "GRAI", "WOOD", "IORE",
+                "STEL", "VALU", null, null, null, null, null, null, null, null, null,
+                null, null, "LMBR", "LUBR", "PETR"];
     default:
         return [];
     }
@@ -1084,6 +1090,17 @@ function DefineCargosBySettings(economy)
             ::CargoCatList <- [CatLabels.PUBLIC_SERVICES,CatLabels.RAW_MATERIALS,CatLabels.PROCESSED_MATERIALS,CatLabels.FINAL_PRODUCTS];
             ::CargoMinPopDemand <- [0,500,1500,4000];
             ::CargoPermille <- [60,35,25,15];
+            ::CargoDecay <- [0.4,0.3,0.2,0.1];
+            break;
+        case(Economies.DEFAULTINDPLUS__TEMPERATE): // DefaultIndustriesPlus Temperate
+            ::CargoLimiter <- [0,2];
+            ::CargoCat <- [[0,2],
+                       [1,3,4,6,7,8],
+                       [9,22,23,24],
+                       [5,10]];
+            ::CargoCatList <- [CatLabels.PUBLIC_SERVICES,CatLabels.RAW_MATERIALS,CatLabels.PROCESSED_MATERIALS,CatLabels.FINAL_PRODUCTS];
+            ::CargoMinPopDemand <- [0,500,1500,4000];
+            ::CargoPermille <- [60,40,25,15];
             ::CargoDecay <- [0.4,0.3,0.2,0.1];
             break;
         default:

--- a/lang/english.txt
+++ b/lang/english.txt
@@ -152,6 +152,7 @@ STR_ECONOMY_ITI2                :Improved Town Industries
 STR_ECONOMY_REAL                :Real Industries
 STR_ECONOMY_MINIMALIST          :Minimalist Industries
 STR_ECONOMY_PIRS                :Pikka's Industries Redux Set (PIRS 2022)
+STR_ECONOMY_DEFAULTINDPLUS_TEMPERATE:DefaultIndustriesPlus Temperate
 
 ##### ETERNAL LOVE #####
 STR_ETERNAL_LOVE_OUTSTANDING    :outstanding

--- a/lang/french.txt
+++ b/lang/french.txt
@@ -117,6 +117,9 @@ STR_ECONOMY_LUMBERJACK          :Lumberjack Industries
 STR_ECOMONY_WRBI                :Wannaroo Basic Industries
 STR_ECONOMY_ITI2                :Improved Town Industries
 STR_ECONOMY_REAL                :Real Industries
+STR_ECONOMY_MINIMALIST          :Minimalist Industries
+STR_ECONOMY_PIRS                :Pikka's Industries Redux Set (PIRS 2022)
+STR_ECONOMY_DEFAULTINDPLUS_TEMPERATE:DefaultIndustriesPlus - Environnement tempéré
 
 ##### ETERNAL LOVE #####
 STR_ETERNAL_LOVE_OUTSTANDING    :exceptionnel


### PR DESCRIPTION
Hello,

[DefaultIndustriesPlus](https://github.com/embrrFlare/default-industries-plus) is a NewGRF inspired by BSPI. It adds 3 cargoes to the base economy: lumber, lubricant and petrol. It then makes sense to split cargoes into 4 categories.

For now it only supports the temperate environment.

Let me know if that looks good to you!

<img width="1023" height="909" alt="" src="https://github.com/user-attachments/assets/e90c7094-99b9-4de9-aaaa-e7dd7515e7c8" />
